### PR TITLE
Navigator synchronized (Walk / Run states are unsynced)

### DIFF
--- a/ClassLibrary1/DebugTools/DebugMenu.cs
+++ b/ClassLibrary1/DebugTools/DebugMenu.cs
@@ -81,6 +81,16 @@ namespace ONI_MP.DebugTools
             if (GUILayout.Button("Leave lobby"))
                 SteamLobby.LeaveLobby();
 
+            if (GUILayout.Button("Client disconnect"))
+            {
+                var n = nameof(WorldDamage);
+                GameClient.CacheCurrentServer();
+                GameClient.Disconnect();
+            }
+
+            if (GUILayout.Button("Reconnect"))
+                GameClient.ReconnectFromCache();
+
             GUILayout.Space(10);
 
             if (MultiplayerSession.InSession)

--- a/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
+++ b/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
@@ -5,7 +5,7 @@ using ONI_MP.DebugTools;
 
 namespace ONI_MP.Networking.Components
 {
-    public class EntityPositionSender : KMonoBehaviour
+    public class EntityPositionHandler : KMonoBehaviour
     {
         private Vector3 lastSentPosition;
         private float timer;
@@ -29,7 +29,7 @@ namespace ONI_MP.Networking.Components
         private void Update()
         {
             // Block clients from sending position data
-            if (MultiplayerSession.IsClient || networkedEntity == null)
+            if (networkedEntity == null)
                 return;
 
             // Only send when in a session and host
@@ -38,6 +38,17 @@ namespace ONI_MP.Networking.Components
                 return;
             }
 
+            if(MultiplayerSession.IsClient)
+            {
+                return;
+            }
+
+            // Host sends the positionPacket every x milliseconds
+            SendPositionPacket();
+        }
+
+        private void SendPositionPacket()
+        {
             timer += Time.unscaledDeltaTime;
             if (timer < SendInterval)
                 return;

--- a/ClassLibrary1/Networking/Components/UIVisibilityController.cs
+++ b/ClassLibrary1/Networking/Components/UIVisibilityController.cs
@@ -19,7 +19,7 @@ namespace ONI_MP.Components
 
         private void Update()
         {
-            UpdatePauseButton();
+            //UpdatePauseButton();
         }
 
         void UpdatePauseButton()

--- a/ClassLibrary1/Networking/IPacket.cs
+++ b/ClassLibrary1/Networking/IPacket.cs
@@ -15,6 +15,7 @@ namespace ONI_MP.Networking
         void Deserialize(BinaryReader reader);
 
         void OnDispatched();
+
     }
 
 }

--- a/ClassLibrary1/Networking/Packets/NavigatorPathPacket.cs
+++ b/ClassLibrary1/Networking/Packets/NavigatorPathPacket.cs
@@ -179,7 +179,7 @@ namespace ONI_MP.Networking.Packets
             if (!navigator)
                 return false;
 
-            if (Steps == null || Steps.Count < 2)
+            if (Steps == null/* || Steps.Count < 2*/)
             {
                 DebugConsole.LogWarning($"[NavigatorPathPacket] Received invalid path for {NetId}");
                 return false;

--- a/ClassLibrary1/Networking/SteamLobby.cs
+++ b/ClassLibrary1/Networking/SteamLobby.cs
@@ -60,6 +60,9 @@ namespace ONI_MP.Networking
                 if (MultiplayerSession.IsHost)
                     GameServer.Shutdown();
 
+                if (MultiplayerSession.IsClient)
+                    GameClient.Disconnect();
+
                 SteamMatchmaking.LeaveLobby(CurrentLobby);
                 MultiplayerSession.Clear();
                 CurrentLobby = CSteamID.Nil;

--- a/ClassLibrary1/Patches/GamePatch.cs
+++ b/ClassLibrary1/Patches/GamePatch.cs
@@ -27,7 +27,6 @@ namespace ONI_MP.Patches
         public static void OnSpawnPostfix()
         {
             PacketHandler.readyToProcess = true;
-            DebugConsole.Log("Ready to process packets!");
         }
     }
 }

--- a/ClassLibrary1/Patches/KInstantiatePatch.cs
+++ b/ClassLibrary1/Patches/KInstantiatePatch.cs
@@ -22,7 +22,7 @@ public static class KInstantiatePatch
         if (MultiplayerSession.IsClient)
         {
             //DebugConsole.Log($"[MP] Blocked KInstantiate on client for prefab '{original?.name}'");
-            return false; // Prevent instantiation
+            return true; // Prevent instantiation
         }
 
         return true; // Allow host to instantiate

--- a/ClassLibrary1/Patches/MinionPatch.cs
+++ b/ClassLibrary1/Patches/MinionPatch.cs
@@ -22,6 +22,6 @@ public static class MinionPatch
             __result.AddOrGet<NetworkIdentity>();
             DebugConsole.Log("[NetworkIdentity] Injected via MinionConfig.CreatePrefab");
         }
-        //__result.AddOrGet<EntityPositionSender>();
+        //__result.AddOrGet<EntityPositionHandler>();
     }
 }

--- a/ClassLibrary1/Patches/MinionPatch.cs
+++ b/ClassLibrary1/Patches/MinionPatch.cs
@@ -22,6 +22,6 @@ public static class MinionPatch
             __result.AddOrGet<NetworkIdentity>();
             DebugConsole.Log("[NetworkIdentity] Injected via MinionConfig.CreatePrefab");
         }
-        __result.AddOrGet<EntityPositionSender>();
+        //__result.AddOrGet<EntityPositionSender>();
     }
 }

--- a/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
+++ b/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System.Security.Principal;
+using HarmonyLib;
 using ONI_MP.DebugTools;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
@@ -10,22 +11,38 @@ namespace ONI_MP.Patches.Navigation
     [HarmonyPatch(typeof(Navigator), nameof(Navigator.AdvancePath))]
     public static class NavigatorPatch
     {
-        static void Prefix(Navigator __instance)
+        static bool Prefix(Navigator __instance)
         {
             if (!__instance.path.IsValid() || __instance.path.nodes == null || __instance.path.nodes.Count == 0)
-                return;
+                return true;
 
+            // In Singleplayer
             if (!MultiplayerSession.InSession)
-                return;
+                return true;
 
+            // Not networked. Allow
             if (!__instance.TryGetComponent<NetworkIdentity>(out var identity))
-                return;
+                return true;
 
             // Only the host can inform clients where to go
-            if (!MultiplayerSession.IsHost)
-                return;
-            
+            if (MultiplayerSession.IsHost)
+            {
+                SendNavigationPacket(__instance, identity);
+                //DebugNavigationPath(__instance);
+                return true;
+            }
 
+            var t = nameof(WorldDamage);
+            if(__instance.GetCanAdvance())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void SendNavigationPacket(Navigator __instance, NetworkIdentity identity)
+        {
             var packet = new NavigatorPathPacket
             {
                 NetId = identity.NetId
@@ -42,7 +59,10 @@ namespace ONI_MP.Patches.Navigation
             }
 
             PacketSender.SendToAll(packet);
+        }
 
+        private static void DebugNavigationPath(Navigator __instance)
+        {
             string log = $"[Navigator AdvancePath] Sent path for {__instance.name} with {__instance.path.nodes.Count} steps.";
             for (int i = 0; i < __instance.path.nodes.Count; i++)
             {
@@ -56,19 +76,29 @@ namespace ONI_MP.Patches.Navigation
     }
 
     [HarmonyPatch(typeof(Navigator), nameof(Navigator.GoTo), new[] {
-        typeof(KMonoBehaviour), typeof(CellOffset[]), typeof(NavTactic)
-    })]
+    typeof(KMonoBehaviour), typeof(CellOffset[]), typeof(NavTactic)
+})]
     public static class Navigator_GoTo_Target_Patch
     {
-        static bool Prefix()
+        static bool Prefix(Navigator __instance)
         {
-            if(!MultiplayerSession.InSession)
+            if (!MultiplayerSession.InSession)
             {
-                return true;
+                return true; // Not in a multiplayer session, allow
             }
 
-            // Only allow host to initiate target-based pathing
-            return MultiplayerSession.IsHost;
+            if (__instance.TryGetComponent<NetworkIdentity>(out var netIdentity))
+            {
+                // Only allow host can initiate
+                return MultiplayerSession.IsHost;
+            }
+            else
+            {
+                // A non networked object. Default to vanilla behavior
+                return true;
+            }
         }
     }
+
+
 }

--- a/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
+++ b/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
@@ -32,7 +32,6 @@ namespace ONI_MP.Patches.Navigation
                 return true;
             }
 
-            var t = nameof(WorldDamage);
             if(__instance.GetCanAdvance())
             {
                 return true;

--- a/ClassLibrary1/Patches/SaveLoaderPatch.cs
+++ b/ClassLibrary1/Patches/SaveLoaderPatch.cs
@@ -15,6 +15,10 @@ namespace ONI_MP.Patches
         {
             TryCreateLobbyAfterLoad("[Multiplayer] Lobby created after world load.");
             PacketHandler.readyToProcess = true;
+            if(MultiplayerSession.InSession)
+            {
+                SpeedControlScreen.Instance?.Unpause(false); // Unpause the game
+            }
         }
 
         [HarmonyPostfix]

--- a/ClassLibrary1/Patches/SpeedControlPausePatch.cs
+++ b/ClassLibrary1/Patches/SpeedControlPausePatch.cs
@@ -15,7 +15,7 @@ namespace ONI_MP.Patches
             if (MultiplayerSession.InSession)
             {
                 Debug.Log("[ONI_MP] Pause prevented during multiplayer session.");
-                return false;
+                return true;
             }
 
             return true;


### PR DESCRIPTION
The navigator is synced and duplicants will only move when the server tells them to move and where to go.

Known issue:

- A duplicant on the client might RUN to their destination but be walking on the host and vise versa
- Because building etc is not synced things can get desynced fast.
- It's not 100% perfect