### PR TITLE
Fix NullReferenceException in Assignable patches during object cleanup

### DIFF
--- a/ClassLibrary1/Patches/World/SideScreen/AssignablePatches.cs
+++ b/ClassLibrary1/Patches/World/SideScreen/AssignablePatches.cs
@@ -17,6 +17,7 @@ namespace ONI_MP.Patches.World.SideScreen
 		{
 			if (AssignmentPacket.IsApplying) return;
 			if (!MultiplayerSession.InSession) return;
+			if (__instance == null || __instance.gameObject == null) return;
 
 			var buildingIdentity = __instance.gameObject.AddOrGet<NetworkIdentity>();
 			buildingIdentity.RegisterIdentity();
@@ -76,6 +77,7 @@ namespace ONI_MP.Patches.World.SideScreen
 		{
 			if (AssignmentPacket.IsApplying) return;
 			if (!MultiplayerSession.InSession) return;
+			if (__instance == null || __instance.gameObject == null) return;
 
 			var buildingIdentity = __instance.gameObject.AddOrGet<NetworkIdentity>();
 			buildingIdentity.RegisterIdentity();


### PR DESCRIPTION
Error:
```
NullReferenceException: Object reference not set to an instance of an object
ONI_MP.Patches.World.SideScreen.Assignable_Assign_Patch.Postfix (Assignable __instance, IAssignableIdentity new_assignee) (at <6c9069bb419e416ba80bcc2a0a4cf2bc>:0)
(wrapper dynamic-method) Assignable.Assignable.Assign_Patch1(Assignable,IAssignableIdentity)
Ownable.Assign (IAssignableIdentity new_assignee) (at <c249d7c3f60846a5bd531f8cae02e382>:0)
(wrapper dynamic-method) Assignable.Assignable.Unassign_Patch1(Assignable)
Assignable.OnCleanUp () (at <c249d7c3f60846a5bd531f8cae02e382>:0)
KMonoBehaviour.OnDestroy () (at <eeaae6bd36c2418387bac55a246d67a2>:0)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
LogCatcher:UnityEngine.ILogHandler.LogException(Exception, Object)
UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
Build: U57-704096-V
```

When an assignable object is destroyed, OnCleanUp() calls Unassign() which triggers our patch. At this point, gameObject is already null/destroyed.

Fixed it by adding null checks to both Assign and Unassign patches
