### PR TITLE
Improve world sync coverage and reduce log noise

### DIFF
--- a/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
@@ -118,6 +118,7 @@ namespace ONI_MP.Networking.Components
 
 		// Cached reflection field
 		private static System.Reflection.FieldInfo _batteryJoulesField;
+		private static bool _batteryFieldLookupAttempted = false;
 
 		// Static handler for client-side reception
 		public static void HandlePacket(StructureStatePacket packet)
@@ -136,9 +137,10 @@ namespace ONI_MP.Networking.Components
 				// JoulesAvailable is read-only, set backing field via reflection
 				try
 				{
-					if (_batteryJoulesField == null)
+					if (_batteryJoulesField == null && !_batteryFieldLookupAttempted)
 					{
-						_batteryJoulesField = typeof(Battery).GetField("joulesAvailable", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+						_batteryFieldLookupAttempted = true;
+						_batteryJoulesField = typeof(Battery).GetField("joulesAvailable", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 					}
 					if (_batteryJoulesField != null)
 					{

--- a/ClassLibrary1/Networking/Components/WorldStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/WorldStateSyncer.cs
@@ -34,6 +34,28 @@ namespace ONI_MP.Networking.Components
 		private ushort[] _shadowElements;
 		private float[] _shadowMass;
 
+		// Rotating background scan - covers off-screen areas
+		private const int BG_SCAN_CHUNK_SIZE = 32;
+		private int _bgScanIndex = 0;
+
+		// Pinned areas - always synced regardless of viewport
+		private static readonly List<RectInt> _pinnedAreas = new List<RectInt>();
+
+		public static void PinArea(int x, int y, int width, int height)
+		{
+			_pinnedAreas.Add(new RectInt(x, y, width, height));
+		}
+
+		public static void UnpinArea(int x, int y, int width, int height)
+		{
+			_pinnedAreas.RemoveAll(r => r.x == x && r.y == y && r.width == width && r.height == height);
+		}
+
+		public static void ClearPinnedAreas()
+		{
+			_pinnedAreas.Clear();
+		}
+
 		private readonly Dictionary<ulong, RectInt> _clientViewports = new Dictionary<ulong, RectInt>();
 
 		private void Awake()
@@ -83,9 +105,8 @@ namespace ONI_MP.Networking.Components
 
 			try
 			{
-				// Adaptive gas sync - double interval if FPS is low
-				float fps = 1f / Time.unscaledDeltaTime;
-				_effectiveGasInterval = fps < 30 ? 3f : GAS_SYNC_INTERVAL;
+				// Adaptive gas sync based on FPS and client count
+				_effectiveGasInterval = GAS_SYNC_INTERVAL * GetSyncMultiplier();
 
 				if (Time.unscaledTime - _lastGasSyncTime > _effectiveGasInterval)
 				{
@@ -602,11 +623,62 @@ namespace ONI_MP.Networking.Components
 				ScanArea(x1, y1, x2, y2);
 			}
 
+			// Scan pinned areas
+			foreach (var rect in _pinnedAreas)
+			{
+				int px1 = Mathf.Max(0, rect.xMin);
+				int py1 = Mathf.Max(0, rect.yMin);
+				int px2 = Mathf.Min(Grid.WidthInCells, rect.xMax);
+				int py2 = Mathf.Min(Grid.HeightInCells, rect.yMax);
+				cellsScanned += (px2 - px1) * (py2 - py1);
+				ScanArea(px1, py1, px2, py2);
+			}
+
+			// Rotating background scan - covers entire map over ~30 seconds
+			if (_shadowElements != null)
+			{
+				int totalCells = Grid.CellCount;
+				int totalChunks = Mathf.CeilToInt((float)totalCells / (BG_SCAN_CHUNK_SIZE * BG_SCAN_CHUNK_SIZE));
+
+				int chunkX = (_bgScanIndex % Mathf.CeilToInt((float)Grid.WidthInCells / BG_SCAN_CHUNK_SIZE)) * BG_SCAN_CHUNK_SIZE;
+				int chunkY = (_bgScanIndex / Mathf.CeilToInt((float)Grid.WidthInCells / BG_SCAN_CHUNK_SIZE)) * BG_SCAN_CHUNK_SIZE;
+
+				int bgX2 = Mathf.Min(chunkX + BG_SCAN_CHUNK_SIZE, Grid.WidthInCells);
+				int bgY2 = Mathf.Min(chunkY + BG_SCAN_CHUNK_SIZE, Grid.HeightInCells);
+
+				cellsScanned += (bgX2 - chunkX) * (bgY2 - chunkY);
+				ScanArea(chunkX, chunkY, bgX2, bgY2);
+
+				_bgScanIndex = (_bgScanIndex + 1) % Mathf.Max(1, totalChunks);
+			}
+
 			// Flush the batcher
 			int packetSize = ONI_MP.Misc.World.WorldUpdateBatcher.Flush();
 
 			sw.Stop();
 			SyncStats.RecordSync(SyncStats.Gas, cellsScanned, packetSize, sw.ElapsedMilliseconds);
+		}
+
+		/// <summary>
+		/// Adaptive sync frequency based on FPS and client count.
+		/// Returns multiplier: 1.0 (normal) to 6.0 (heavy load).
+		/// </summary>
+		private float GetSyncMultiplier()
+		{
+			float multiplier = 1f;
+
+			// FPS factor
+			float fps = 1f / Mathf.Max(Time.unscaledDeltaTime, 0.001f);
+			if (fps < 20f) multiplier *= 3f;
+			else if (fps < 30f) multiplier *= 2f;
+			else if (fps < 45f) multiplier *= 1.5f;
+
+			// Client count factor
+			int clients = MultiplayerSession.ConnectedPlayers.Count;
+			if (clients > 4) multiplier *= 2f;
+			else if (clients > 2) multiplier *= 1.5f;
+
+			return Mathf.Min(multiplier, 6f);
 		}
 
 		private void ScanArea(int x1, int y1, int x2, int y2)

--- a/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
+++ b/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
@@ -12,6 +12,11 @@ namespace ONI_MP.Networking
 		private static readonly Dictionary<int, NetworkIdentity> identities = new Dictionary<int, NetworkIdentity>();
 		private static readonly System.Random rng = new System.Random();
 
+		private static int _lookupFailCount = 0;
+		private static float _lastFailLogTime = 0f;
+
+		public static int Count => identities?.Count ?? 0;
+
 		public static int Register(NetworkIdentity entity)
 		{
 			using var _ = Profiler.Scope();
@@ -75,7 +80,12 @@ namespace ONI_MP.Networking
 			bool found = identities.TryGetValue(netId, out entity);
 			if (!found)
 			{
-				DebugConsole.LogWarning($"[NetEntityRegistry] ERROR: Requested NetId {netId} NOT FOUND in registry. Current count: {identities.Count}");
+				_lookupFailCount++;
+				if (_lookupFailCount <= 3 || _lookupFailCount % 500 == 0 || Time.unscaledTime - _lastFailLogTime > 1f)
+				{
+					_lastFailLogTime = Time.unscaledTime;
+					DebugConsole.LogWarning($"[Registry] Lookup failed (#{_lookupFailCount}): NetId {netId} not found. Count: {identities.Count}");
+				}
 			}
 			return found;
 		}
@@ -106,6 +116,7 @@ namespace ONI_MP.Networking
 			using var _ = Profiler.Scope();
 
 			identities.Clear();
+			_lookupFailCount = 0;
 		}
 
 		public static IEnumerable<NetworkIdentity> AllIdentities => identities.Values;


### PR DESCRIPTION
## Summary
- Add rotating 32x32 background scan to WorldStateSyncer to catch off-screen element/mass changes (~30s full map cycle)
- Add interest area pinning API (`PinArea`/`UnpinArea`) for always-synced regions (e.g. geyser rooms)
- Enhance adaptive sync with FPS tiers and client count scaling (1x-6x multiplier, replaces simple fps<30 check)
- Guard battery reflection lookup to prevent repeated failed GetField calls every frame
- Throttle NetworkIdentityRegistry lookup failure warnings to reduce log spam

## Details
**WorldStateSyncer.cs**:
- Background scan advances one 32x32 chunk per sync tick, cycling through the entire map
- `GetSyncMultiplier()` considers FPS (<20: 3x, <30: 2x, <45: 1.5x) and client count (>4: 2x, >2: 1.5x), capped at 6x
- Pinned areas are scanned every tick alongside viewports

**StructureStateSyncer.cs**:
- `_batteryFieldLookupAttempted` flag prevents reflection spam on failure

**NetworkIdentityRegistry.cs**:
- Logs first 3 failures, then every 500th, or max once per second
- Added `Count` property for diagnostics

## Test plan
- [ ] Host a multiplayer session and verify gas/liquid sync in viewed areas still works
- [ ] Move camera away from an area, wait 30s, return — verify elements updated
- [ ] Check logs for reduced spam during gameplay with missing entities