### PR TITLE
Add auto-reconnect, packet timeout, and server error guard

### DIFF
--- a/ClassLibrary1/Networking/GameClient.cs
+++ b/ClassLibrary1/Networking/GameClient.cs
@@ -33,6 +33,12 @@ namespace ONI_MP.Networking
 		public static bool IsHardSyncInProgress = false;
 		private static bool _modVerificationSent = false;
 
+		// Auto-reconnect state
+		private static bool _autoReconnecting = false;
+		private static int _reconnectAttempt = 0;
+		private const int MAX_RECONNECT_ATTEMPTS = 5;
+		private const float RECONNECT_BASE_DELAY = 1f;
+
 
 		private struct CachedConnectionInfo
 		{
@@ -282,6 +288,9 @@ namespace ONI_MP.Networking
 				// Fechar overlay se reconectou com sucesso
 				MultiplayerOverlay.Close();
 
+				// Reset reconnect state on successful connection
+				ResetReconnectState();
+
 				DebugConsole.Log("[GameClient] Reconnection setup complete");
 			}
 			else
@@ -290,8 +299,56 @@ namespace ONI_MP.Networking
 			}
 		}
 
+		private static IEnumerator AutoReconnectCoroutine()
+		{
+			if (_autoReconnecting) yield break;
+			_autoReconnecting = true;
+			_reconnectAttempt++;
+
+			float delay = Mathf.Min(RECONNECT_BASE_DELAY * Mathf.Pow(2, _reconnectAttempt - 1), 30f);
+			DebugConsole.Log($"[GameClient] Auto-reconnect attempt {_reconnectAttempt}/{MAX_RECONNECT_ATTEMPTS} in {delay}s");
+			MultiplayerOverlay.Show($"Reconnecting... attempt {_reconnectAttempt}/{MAX_RECONNECT_ATTEMPTS}");
+
+			yield return new WaitForSecondsRealtime(delay);
+
+			if (!Utils.IsInGame())
+			{
+				DebugConsole.Log("[GameClient] No longer in game, aborting reconnect");
+				_autoReconnecting = false;
+				_reconnectAttempt = 0;
+				yield break;
+			}
+
+			try
+			{
+				ReconnectToSession();
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogError($"[GameClient] Reconnect attempt {_reconnectAttempt} failed: {ex}");
+			}
+
+			_autoReconnecting = false;
+		}
+
+		public static void ResetReconnectState()
+		{
+			_autoReconnecting = false;
+			_reconnectAttempt = 0;
+		}
+
 		private static IEnumerator ShowMessageAndReturnToTitle(string reason = "", string message = "")
 		{
+			// Auto-reconnect if still in game and under max attempts
+			if (Utils.IsInGame() && _reconnectAttempt < MAX_RECONNECT_ATTEMPTS)
+			{
+				CoroutineRunner.RunOne(AutoReconnectCoroutine());
+				yield break;
+			}
+			// Reset on final failure
+			_reconnectAttempt = 0;
+			_autoReconnecting = false;
+
             MultiplayerOverlay.Show(string.Format(STRINGS.UI.MP_OVERLAY.CLIENT.LOST_CONNECTION, reason, message));
 			//SaveHelper.CaptureWorldSnapshot();
 			yield return new WaitForSecondsRealtime(3f);

--- a/ClassLibrary1/Networking/GameServer.cs
+++ b/ClassLibrary1/Networking/GameServer.cs
@@ -72,11 +72,18 @@ namespace ONI_MP.Networking
 			switch (State)
 			{
 				case ServerState.Started:
-					NetworkConfig.TransportServer.Update();
-                    NetworkConfig.TransportServer.OnMessageRecieved();
+					try
+					{
+						NetworkConfig.TransportServer.Update();
+						NetworkConfig.TransportServer.OnMessageRecieved();
 
-                    // Check for lost chunks and retransmit specific missing chunks
-                    SaveFileTransferManager.CheckForLostChunks();
+						// Check for lost chunks and retransmit specific missing chunks
+						SaveFileTransferManager.CheckForLostChunks();
+					}
+					catch (Exception ex)
+					{
+						DebugConsole.LogError($"[GameServer] Error in server update: {ex}");
+					}
 					break;
 
 				case ServerState.Preparing:

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketHandler.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketHandler.cs
@@ -11,7 +11,7 @@ namespace ONI_MP.Networking.Packets.Architecture
 	public static class PacketHandler
 	{
 		private static bool _readyToProcess = true;
-		private static float _notReadySince = 0f;
+		private static float _notReadySince = float.MaxValue;
 		private const float NOT_READY_TIMEOUT = 60f;
 
 		public static bool readyToProcess

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketHandler.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketHandler.cs
@@ -3,21 +3,43 @@ using System.IO;
 using ONI_MP.DebugTools;
 using ONI_MP.Networking;
 using Shared.Profiling;
+using UnityEngine;
 
 namespace ONI_MP.Networking.Packets.Architecture
 {
 
 	public static class PacketHandler
 	{
-		public static bool readyToProcess = true;
+		private static bool _readyToProcess = true;
+		private static float _notReadySince = 0f;
+		private const float NOT_READY_TIMEOUT = 60f;
+
+		public static bool readyToProcess
+		{
+			get => _readyToProcess;
+			set
+			{
+				if (!value)
+					_notReadySince = Time.unscaledTime;
+				_readyToProcess = value;
+			}
+		}
 
 		public static void HandleIncoming(byte[] data)
 		{
 			using var _ = Profiler.Scope();
 
-			if (!readyToProcess)
+			if (!_readyToProcess)
 			{
-				return;
+				if (Time.unscaledTime - _notReadySince > NOT_READY_TIMEOUT)
+				{
+					DebugConsole.LogWarning($"[PacketHandler] readyToProcess was false for >{NOT_READY_TIMEOUT}s — force-recovering");
+					_readyToProcess = true;
+				}
+				else
+				{
+					return;
+				}
 			}
 
 			using (var ms = new MemoryStream(data))


### PR DESCRIPTION
## Summary
- Add auto-reconnect with exponential backoff on unexpected disconnect (1s→2s→4s→...→30s, max 5 attempts)
- Add 60-second timeout for `readyToProcess` to prevent indefinite client freeze during failed hard sync
- Wrap server update loop in try-catch to prevent a single bad packet from crashing the host

## Details
**GameClient.cs**:
- `AutoReconnectCoroutine()` with re-entrancy guard and exponential backoff
- Transport-agnostic: uses `ReconnectToSession()` abstraction, works with both Steam and Riptide
- Triggers from `ShowMessageAndReturnToTitle()` when client is still in-game
- Resets on successful reconnection via `ContinueConnectionFlow()`

**PacketHandler.cs**:
- `readyToProcess` converted from field to property with timestamp tracking
- If blocked for >60s, force-recovers with warning log

**GameServer.cs**:
- `ServerState.Started` case wrapped in try-catch to isolate packet processing failures

## Test plan
- [ ] Disconnect host briefly during gameplay — verify client auto-reconnects
- [ ] Verify reconnect overlay shows attempt count
- [ ] Verify client doesn't freeze indefinitely during failed hard sync
- [ ] Verify host continues running after receiving a malformed packet