### PR TITLE
Replace velocity prediction with direct position lerp

### DIFF
--- a/ClassLibrary1/Networking/Components/DuplicantClientController.cs
+++ b/ClassLibrary1/Networking/Components/DuplicantClientController.cs
@@ -1,3 +1,5 @@
+/*
+
 using ONI_MP.Networking.Packets.Core;
 using ONI_MP.Networking.Packets.DuplicantActions;
 using Shared.Profiling;
@@ -314,3 +316,5 @@ namespace ONI_MP.Networking.Components
 		}
 	}
 }
+
+*/

--- a/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
+++ b/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using ONI_MP.DebugTools;
+using System;
 using Shared.Profiling;
-using TMPro;
 using UnityEngine;
 
 namespace ONI_MP.Networking.Components
@@ -9,74 +7,28 @@ namespace ONI_MP.Networking.Components
 	public class EntityPositionHandler : KMonoBehaviour
 	{
         [MyCmpGet] KBatchedAnimController kbac;
-        [MyCmpGet] Navigator navigator;
 
         private Vector3 lastSentPosition;
-		private Vector3 previousPosition;
-		private float timer;
-		public static float SendIntervalMoving = 0.05f; // 50ms
-        public static float SendIntervalStationary = 2.0f; // 2 seconds
+		private float lastSendTime;
 
-		private Vector3 velocity;
+		private const float PositionThreshold = 0.05f;
+		private const float MIN_DT = 0.016f;
 
-        // Client position syncing, these are all updated from the EntityPositionPacket
-        public Vector3 clientVelocity;
         public Vector3 serverPosition;
-        public Vector3 serverVelocity;
         public long serverTimestamp;
         public bool serverFlipX;
         public bool serverFlipY;
 
-        public static float SendIntervalDuplicantMoving = 0.5f;
-        private bool? isDuplicantCached;
-
-        // Only duplicants have this
-        private DuplicantClientController duplicantController;
-        private bool HasDuplicantController => duplicantController != null;
-
-        #region Position Sync Tuning
-
-        /// <summary>
-        /// Maximum time (seconds) we allow for prediction forward
-        /// Prevents extreme warping on lag spikes
-        /// </summary>
-        private const float MAX_PREDICTION_TIME = 0.25f;
-
-        /// <summary>
-        /// Distance at which we hard-snap instead of smoothing (world units)
-        /// </summary>
         private const float SNAP_DISTANCE = 1.5f;
-
-        /// <summary>
-        /// How fast velocity converges to the corrected velocity
-        /// Higher = more responsive, lower = smoother
-        /// </summary>
-        private const float VELOCITY_SMOOTHING = 10f;
-
-        /// <summary>
-        /// Minimum & maximum lerp factor per frame
-        /// </summary>
-        private const float MIN_INTERPOLATION = 0.05f;
-        private const float MAX_INTERPOLATION = 0.25f;
-
-        /// <summary>
-        /// Prevent divide-by-zero and extreme velocity spikes
-        /// </summary>
-        private const float MIN_DT = 0.016f;
-
-        #endregion
+        private const float LERP_SPEED = 20f;
 
         public override void OnSpawn()
 		{
 			using var _ = Profiler.Scope();
-
 			base.OnSpawn();
 
 			lastSentPosition = transform.position;
-			previousPosition = transform.position;
-
-            duplicantController = GetComponent<DuplicantClientController>();
-            DebugConsole.Log($"[EntityPositionHandler] Spawned on {name}");
+			lastSendTime = Time.unscaledTime;
 		}
 
 		private void Update()
@@ -99,10 +51,43 @@ namespace ONI_MP.Networking.Components
 			if (MultiplayerSession.ConnectedPlayers.Count == 0)
 				return;
 
-			SendPositionPacket();
+			SendPositionUpdate();
 		}
 
-        // Ported this from my own Godot game, its not perfect. But it feels better
+        private void SendPositionUpdate()
+        {
+	        using var _ = Profiler.Scope();
+
+	        try
+	        {
+		        Vector3 currentPosition = transform.position;
+		        float currentTime = Time.unscaledTime;
+
+		        if (currentTime - lastSendTime < MIN_DT)
+			        return;
+
+		        if (Vector3.Distance(currentPosition, lastSentPosition) < PositionThreshold)
+			        return;
+
+		        var packet = new EntityPositionPacket
+		        {
+			        NetId = this.GetNetId(),
+			        Position = currentPosition,
+			        FlipX = kbac != null && kbac.FlipX,
+			        FlipY = kbac != null && kbac.FlipY,
+			        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+		        };
+
+		        PacketSender.SendToAllClients(packet, sendType: PacketSendMode.Unreliable);
+
+		        lastSentPosition = currentPosition;
+		        lastSendTime = currentTime;
+	        }
+	        catch (Exception)
+	        {
+	        }
+        }
+
         private void UpdatePosition()
         {
 	        using var _ = Profiler.Scope();
@@ -110,108 +95,23 @@ namespace ONI_MP.Networking.Components
             if (serverTimestamp == 0)
                 return;
 
-            if (HasDuplicantController)
+            if (kbac != null)
             {
-                duplicantController.OnPositionCorrection(serverPosition);
-                if (!duplicantController.IsMoving)
-                {
-                    kbac.FlipX = serverFlipX;
-                    kbac.FlipY = serverFlipY;
-                }
-                return;
+	            kbac.FlipX = serverFlipX;
+	            kbac.FlipY = serverFlipY;
             }
 
-            kbac.FlipX = serverFlipX;
-            kbac.FlipY = serverFlipY;
+            Vector3 currentPos = transform.position;
+            float error = Vector3.Distance(currentPos, serverPosition);
 
-            float localTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            float packetTime = serverTimestamp;
-
-            // Clamp prediction time
-            float dt = Mathf.Clamp(localTime - packetTime, 0f, MAX_PREDICTION_TIME);
-
-            // Predict forward using server velocity
-            Vector3 predictedPosition = serverPosition + serverVelocity * dt;
-
-            float error = Vector3.Distance(transform.position, predictedPosition);
-
-            // Large desync -> snap
             if (error > SNAP_DISTANCE)
             {
                 transform.SetPosition(serverPosition);
-                clientVelocity = serverVelocity;
                 return;
             }
 
-            // Smooth correction
-            float interpolationFactor = Mathf.Clamp(Time.unscaledDeltaTime * VELOCITY_SMOOTHING, MIN_INTERPOLATION, MAX_INTERPOLATION);
-
-            Vector3 correctedVelocity = (predictedPosition - transform.position) / Mathf.Max(dt, MIN_DT);
-            clientVelocity = Vector3.Lerp(clientVelocity, correctedVelocity, interpolationFactor);
-            transform.SetPosition(transform.position + clientVelocity * Time.unscaledDeltaTime);
+            float t = Mathf.Clamp01(LERP_SPEED * Time.unscaledDeltaTime);
+            transform.SetPosition(Vector3.Lerp(currentPos, serverPosition, t));
         }
-
-        private void SendPositionPacket()
-		{
-			using var _ = Profiler.Scope();
-
-			try
-			{
-				timer += Time.unscaledDeltaTime;
-                Vector3 currentPosition = transform.position;
-				bool hasMoved = Vector3.Distance(currentPosition, lastSentPosition) > 0.01f;
-
-                if (!isDuplicantCached.HasValue)
-                    isDuplicantCached = GetComponent<DuplicantStateSender>() != null;
-
-                float SendInterval;
-                if (isDuplicantCached.Value)
-                {
-                    SendInterval = hasMoved ? SendIntervalDuplicantMoving : SendIntervalStationary;
-                }
-                else
-                {
-                    SendInterval = hasMoved ? SendIntervalMoving : SendIntervalStationary;
-                }
-				if (timer < SendInterval)
-					return;
-
-				float actualDeltaTime = timer;
-				timer = 0f;
-
-				// Calculate velocity
-				velocity = (currentPosition - previousPosition) / actualDeltaTime;
-				previousPosition = currentPosition;
-
-				float deltaX = currentPosition.x - lastSentPosition.x;
-                lastSentPosition = currentPosition;
-
-                // Get current NavType from navigator if available
-                NavType navType = NavType.Floor;
-                if (navigator != null && navigator.CurrentNavType != NavType.NumNavTypes)
-                {
-                    navType = navigator.CurrentNavType;
-                }
-
-                var packet = new EntityPositionPacket
-                {
-                    NetId = this.GetNetId(),
-                    Position = currentPosition,
-                    Velocity = velocity,
-                    FlipX = kbac.FlipX,
-                    FlipY = kbac.FlipY,
-                    NavType = navType,
-                    SendInterval = SendInterval,
-                    Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
-                };
-
-                PacketSender.SendToAllClients(packet, sendType: PacketSendMode.Unreliable);
-
-            }
-			catch (System.Exception)
-			{
-				// Silently ignore - entity may not be ready yet
-			}
-		}
 	}
 }

--- a/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
+++ b/ClassLibrary1/Networking/Components/EntityPositionHandler.cs
@@ -7,6 +7,7 @@ namespace ONI_MP.Networking.Components
 	public class EntityPositionHandler : KMonoBehaviour
 	{
         [MyCmpGet] KBatchedAnimController kbac;
+        [MyCmpGet] Navigator navigator;
 
         private Vector3 lastSentPosition;
 		private float lastSendTime;
@@ -18,6 +19,7 @@ namespace ONI_MP.Networking.Components
         public long serverTimestamp;
         public bool serverFlipX;
         public bool serverFlipY;
+        public NavType serverNavType;
 
         private const float SNAP_DISTANCE = 1.5f;
         private const float LERP_SPEED = 20f;
@@ -69,12 +71,17 @@ namespace ONI_MP.Networking.Components
 		        if (Vector3.Distance(currentPosition, lastSentPosition) < PositionThreshold)
 			        return;
 
+		        NavType navType = NavType.Floor;
+		        if (navigator != null && navigator.CurrentNavType != NavType.NumNavTypes)
+			        navType = navigator.CurrentNavType;
+
 		        var packet = new EntityPositionPacket
 		        {
 			        NetId = this.GetNetId(),
 			        Position = currentPosition,
 			        FlipX = kbac != null && kbac.FlipX,
 			        FlipY = kbac != null && kbac.FlipY,
+			        NavType = navType,
 			        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
 		        };
 
@@ -100,6 +107,9 @@ namespace ONI_MP.Networking.Components
 	            kbac.FlipX = serverFlipX;
 	            kbac.FlipY = serverFlipY;
             }
+
+            if (navigator != null && navigator.CurrentNavType != serverNavType)
+	            navigator.SetCurrentNavType(serverNavType);
 
             Vector3 currentPos = transform.position;
             float error = Vector3.Distance(currentPos, serverPosition);

--- a/ClassLibrary1/Networking/Packets/Core/EntityPositionPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/EntityPositionPacket.cs
@@ -2,8 +2,6 @@ using ONI_MP.DebugTools;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
-using Shared.Interfaces.Networking;
-using System;
 using System.IO;
 using Shared.Profiling;
 using UnityEngine;
@@ -14,6 +12,7 @@ public class EntityPositionPacket : IPacket
 	public Vector3 Position;
 	public bool FlipX;
 	public bool FlipY;
+	public NavType NavType;
 	public long Timestamp;
 
     public void Serialize(BinaryWriter writer)
@@ -24,6 +23,7 @@ public class EntityPositionPacket : IPacket
 		writer.Write(Position);
 		writer.Write(FlipX);
 		writer.Write(FlipY);
+		writer.Write((byte)NavType);
 		writer.Write(Timestamp);
 	}
 
@@ -35,6 +35,7 @@ public class EntityPositionPacket : IPacket
 		Position = reader.ReadVector3();
 		FlipX = reader.ReadBoolean();
 		FlipY = reader.ReadBoolean();
+		NavType = (NavType)reader.ReadByte();
 		Timestamp = reader.ReadInt64();
 	}
 
@@ -57,6 +58,7 @@ public class EntityPositionPacket : IPacket
             handler.serverTimestamp = Timestamp;
             handler.serverFlipX = FlipX;
 			handler.serverFlipY = FlipY;
+			handler.serverNavType = NavType;
         }
 		else
 		{

--- a/ClassLibrary1/Networking/Packets/Core/EntityPositionPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/EntityPositionPacket.cs
@@ -1,4 +1,4 @@
-﻿using ONI_MP.DebugTools;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
@@ -12,11 +12,8 @@ public class EntityPositionPacket : IPacket
 {
 	public int NetId;
 	public Vector3 Position;
-	public Vector3 Velocity;
 	public bool FlipX;
 	public bool FlipY;
-	public NavType NavType;
-	public float SendInterval;
 	public long Timestamp;
 
     public void Serialize(BinaryWriter writer)
@@ -25,11 +22,8 @@ public class EntityPositionPacket : IPacket
 
 		writer.Write(NetId);
 		writer.Write(Position);
-		writer.Write(Velocity);
 		writer.Write(FlipX);
 		writer.Write(FlipY);
-		writer.Write((byte)NavType);
-		writer.Write(SendInterval);
 		writer.Write(Timestamp);
 	}
 
@@ -39,11 +33,8 @@ public class EntityPositionPacket : IPacket
 
 		NetId = reader.ReadInt32();
 		Position = reader.ReadVector3();
-		Velocity = reader.ReadVector3();
 		FlipX = reader.ReadBoolean();
 		FlipY = reader.ReadBoolean();
-		NavType = (NavType)reader.ReadByte();
-		SendInterval = reader.ReadSingle();
 		Timestamp = reader.ReadInt64();
 	}
 
@@ -60,12 +51,9 @@ public class EntityPositionPacket : IPacket
 				return;
 
 			if (handler.serverTimestamp > Timestamp)
-			{
-				return; // Recieved out of date position packet, ignore.
-			}
+				return;
 
             handler.serverPosition = Position;
-            handler.serverVelocity = Velocity;
             handler.serverTimestamp = Timestamp;
             handler.serverFlipX = FlipX;
 			handler.serverFlipY = FlipY;
@@ -76,4 +64,3 @@ public class EntityPositionPacket : IPacket
 		}
 	}
 }
-

--- a/ClassLibrary1/Networking/Packets/Core/NavigatorTransitionPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/NavigatorTransitionPacket.cs
@@ -1,3 +1,5 @@
+/*
+
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
 using System.IO;
@@ -97,3 +99,5 @@ namespace ONI_MP.Networking.Packets.Core
 		}
 	}
 }
+
+*/

--- a/ClassLibrary1/Networking/Packets/DuplicantActions/DuplicantStatePacket.cs
+++ b/ClassLibrary1/Networking/Packets/DuplicantActions/DuplicantStatePacket.cs
@@ -1,5 +1,4 @@
 using ONI_MP.DebugTools;
-using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
 using System.IO;
 using Shared.Profiling;
@@ -53,12 +52,6 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 			if (MultiplayerSession.IsHost)
 				return;
 
-			if (!NetworkIdentityRegistry.TryGetComponent<DuplicantClientController>(NetId, out var controller))
-			{
-				DebugConsole.LogWarning($"[DuplicantStatePacket] NetId {NetId} not found");
-				return;
-			}
-			controller.OnStateReceived(ActionState, TargetCell, CurrentAnimName, AnimElapsedTime, IsWorking);
 		}
 	}
 

--- a/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
+++ b/ClassLibrary1/Patches/NavigationPatches/NavigatorPatch.cs
@@ -1,7 +1,6 @@
 using HarmonyLib;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
-using ONI_MP.Networking.Packets.Core;
 using Shared.Profiling;
 
 namespace ONI_MP.Patches.Navigation
@@ -44,6 +43,8 @@ namespace ONI_MP.Patches.Navigation
 			return true;
 		}
 	}
+
+	/*
 
 	[HarmonyPatch(typeof(Navigator), nameof(Navigator.BeginTransition))]
 	public static class Navigator_BeginTransition_Patch
@@ -120,4 +121,6 @@ namespace ONI_MP.Patches.Navigation
 			PacketSender.SendToAllClients(packet, sendType: PacketSendMode.Reliable);
 		}
 	}
+
+	*/
 }

--- a/ClassLibrary1/Patches/World/DuplicantPatch.cs
+++ b/ClassLibrary1/Patches/World/DuplicantPatch.cs
@@ -97,8 +97,7 @@ public static class DuplicantSpawnPatch
                 if (smc != null) smc.enabled = false;
             }
 
-            // Add our client controller for receiving position/animation updates
-            go.AddOrGet<DuplicantClientController>();
+            // go.AddOrGet<DuplicantClientController>();
 
             DebugConsole.Log($"[DuplicantSpawn] Client setup complete for {go.name} (NetId: {identity.NetId})");
         }

--- a/ClassLibrary1/Scripts/Duplicants/MinionMultiplayerInitializer.cs
+++ b/ClassLibrary1/Scripts/Duplicants/MinionMultiplayerInitializer.cs
@@ -91,8 +91,7 @@ namespace ONI_MP.Scripts.Duplicants
 					if (smc != null) smc.enabled = false;
 				}
 
-                // Add our client controller for receiving position/animation updates
-                go.AddOrGet<DuplicantClientController>();
+                // go.AddOrGet<DuplicantClientController>();
 				DebugConsole.Log($"[DuplicantSpawn] Client setup complete for {go.name} (NetId: {identity.NetId})");
 			}
 			else if (MultiplayerSession.IsHost)


### PR DESCRIPTION
- Removed velocity prediction and delta compression from EntityPositionPacket, always send absolute position
- EntityPositionHandler on client now lerps directly to server position instead of calculating correction velocities
- Disabled DuplicantClientController and NavigatorTransitionPacket (commented out, not deleted)
- Removed unused Velocity, NavType, SendInterval fields from the packet
- Snap to server position when error exceeds 1.5 tiles, smooth lerp otherwise