### PR TITLE
Chat window QoL improvements

### DIFF
--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -442,6 +442,32 @@ namespace ONI_MP.UI
 			fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 			fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
 
+			var scrollbarGO = new GameObject("Scrollbar", typeof(RectTransform), typeof(Image), typeof(Scrollbar));
+			scrollbarGO.transform.SetParent(scrollGO.transform, false);
+			var scrollbarRT = scrollbarGO.GetComponent<RectTransform>();
+			scrollbarRT.anchorMin = new Vector2(1, 0);
+			scrollbarRT.anchorMax = Vector2.one;
+			scrollbarRT.pivot = new Vector2(1, 1);
+			scrollbarRT.offsetMin = new Vector2(-8, 0);
+			scrollbarRT.offsetMax = Vector2.zero;
+			scrollbarGO.GetComponent<Image>().color = new Color(0.15f, 0.15f, 0.15f, 0.5f);
+
+			var handleGO = new GameObject("Handle", typeof(RectTransform), typeof(Image));
+			handleGO.transform.SetParent(scrollbarGO.transform, false);
+			var handleRT = handleGO.GetComponent<RectTransform>();
+			handleRT.anchorMin = Vector2.zero;
+			handleRT.anchorMax = Vector2.one;
+			handleRT.offsetMin = new Vector2(2, 2);
+			handleRT.offsetMax = new Vector2(-2, -2);
+			handleGO.GetComponent<Image>().color = new Color(0.6f, 0.6f, 0.6f, 0.6f);
+
+			var scrollbar = scrollbarGO.GetComponent<Scrollbar>();
+			scrollbar.handleRect = handleRT;
+			scrollbar.direction = Scrollbar.Direction.BottomToTop;
+			scrollbar.targetGraphic = handleGO.GetComponent<Image>();
+
+			viewportRT.offsetMax = new Vector2(-10, 0);
+
 			var scroll = scrollGO.GetComponent<ScrollRect>();
 			scroll.content = content;
 			scroll.viewport = viewportRT;
@@ -449,6 +475,8 @@ namespace ONI_MP.UI
 			scroll.vertical = true;
 			scroll.movementType = ScrollRect.MovementType.Clamped;
 			scroll.scrollSensitivity = 50f;
+			scroll.verticalScrollbar = scrollbar;
+			scroll.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHideAndExpandViewport;
 
 			// Add layout group and fitter to viewport (optional but can help)
 			viewport.AddComponent<CanvasRenderer>();

--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -444,7 +444,7 @@ namespace ONI_MP.UI
 				return false;
 
 			Vector2 mousePos = Input.mousePosition;
-			return RectTransformUtility.RectangleContainsScreenPoint(Instance.panelRectTransform, mousePos, Camera.main);
+			return RectTransformUtility.RectangleContainsScreenPoint(Instance.panelRectTransform, mousePos, null);
 		}
 
 		private void OnInputSubmitted(string text)

--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -2,7 +2,6 @@
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Social;
-using Steamworks;
 using System;
 using System.Collections.Generic;
 using Shared.Profiling;
@@ -10,8 +9,6 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using Utils = ONI_MP.Misc.Utils;
-using EventSystem2Syntax;
-using static UnityEngine.GraphicsBuffer;
 
 namespace ONI_MP.UI
 {
@@ -35,6 +32,7 @@ namespace ONI_MP.UI
 		}
 
 		private static List<PendingMessage> pendingMessages = new List<PendingMessage>();
+		private static List<PendingMessage> chatHistory = new List<PendingMessage>();
 
 		public static void Show()
 		{
@@ -56,6 +54,19 @@ namespace ONI_MP.UI
 			rt.anchoredPosition = new Vector2(0, 0);
 
 			Instance.SetupUI();
+
+			Game.Instance?.Subscribe(MP_HASHES.OnPlayerJoined, _ => SendChatHistoryToClients());
+		}
+
+		private static void SendChatHistoryToClients()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.IsHost || chatHistory.Count == 0)
+				return;
+
+			var packet = new ChatHistorySyncPacket(chatHistory);
+			PacketSender.SendToAllClients(packet);
 		}
         private void SetupUI()
         {
@@ -203,6 +214,15 @@ namespace ONI_MP.UI
 			inputField.gameObject.SetActive(true);
 		}
 
+		public void ClearMessages()
+		{
+			using var _ = Profiler.Scope();
+
+			foreach (var tmp in messages.Values)
+				Destroy(tmp.gameObject);
+			messages.Clear();
+		}
+
 		public void AddMessage(long timestamp, string text)
 		{
 			using var _ = Profiler.Scope();
@@ -245,6 +265,8 @@ namespace ONI_MP.UI
 			fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
 
             messages.Add(timestamp, tmp);
+			if (text != STRINGS.UI.MP_CHATWINDOW.CHAT_INITIALIZED)
+				chatHistory.Add(new PendingMessage { timestamp = timestamp, message = text });
 
 			// Manually rebuild layout and force scroll to bottom
 			LayoutRebuilder.ForceRebuildLayoutImmediate(messageContainer);

--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -52,6 +52,7 @@ namespace ONI_MP.UI
 			rt.anchorMin = new Vector2(0.5f, 0.5f);
 			rt.anchorMax = new Vector2(0.5f, 0.5f);
 			rt.pivot = new Vector2(0.5f, 0.5f);
+			rt.sizeDelta = Vector2.zero;
 			rt.anchoredPosition = new Vector2(0, 0);
 
 			Instance.SetupUI();
@@ -81,8 +82,10 @@ namespace ONI_MP.UI
 
             var drag = header.AddComponent<UIDragHandler>();
             drag.target = rootRT;
-			//rootRT.anchoredPosition = new Vector2(737, -407);
-			Clamp(new Vector2(737, -407), rootRT);
+			RectTransform canvasRect = GameScreenManager.Instance.ssOverlayCanvas.GetComponent<RectTransform>();
+			float startX = canvasRect.rect.width * 0.5f - rootRT.rect.width * (1f - rootRT.pivot.x) - 20f;
+			float startY = -canvasRect.rect.height * 0.5f + rootRT.rect.height * rootRT.pivot.y + 130f;
+			rootRT.anchoredPosition = new Vector2(startX, startY);
 
             var chatboxContents = new GameObject("Chatbox_Contents");
             chatboxContents.transform.SetParent(chatWindowRoot.transform, false);
@@ -464,19 +467,15 @@ namespace ONI_MP.UI
         }
         public void Clamp(Vector2 position, RectTransform target)
 		{
-            RectTransform parent = target.parent as RectTransform;
 			Vector2 newPos = position;
 
-            // Clamp to parent/canvas bounds
             RectTransform canvasRect = GameScreenManager.Instance.ssOverlayCanvas.GetComponent<RectTransform>();
 
-            float halfWidth = target.rect.width * 0.5f;
-            float halfHeight = target.rect.height * 0.5f;
-
-            float leftLimit = -canvasRect.rect.width * 0.5f + halfWidth;
-            float rightLimit = canvasRect.rect.width * 0.5f - halfWidth;
-            float bottomLimit = -canvasRect.rect.height * 0.5f + halfHeight;
-            float topLimit = canvasRect.rect.height * 0.5f - halfHeight;
+            float padding = 10f;
+            float leftLimit = -canvasRect.rect.width * 0.5f + target.rect.width * target.pivot.x + padding;
+            float rightLimit = canvasRect.rect.width * 0.5f - target.rect.width * (1f - target.pivot.x) - padding;
+            float bottomLimit = -canvasRect.rect.height * 0.5f + target.rect.height * target.pivot.y + padding;
+            float topLimit = canvasRect.rect.height * 0.5f - target.rect.height * (1f - target.pivot.y) - padding;
 
             newPos.x = Mathf.Clamp(newPos.x, leftLimit, rightLimit);
             newPos.y = Mathf.Clamp(newPos.y, bottomLimit, topLimit);

--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -23,6 +23,7 @@ namespace ONI_MP.UI
 
 		private GameObject header;
 		private GameObject chatbox;
+		private GameObject resizeHandles;
 		private bool expanded = false;
 
 		public struct PendingMessage
@@ -87,7 +88,7 @@ namespace ONI_MP.UI
             headerRT.anchorMin = new Vector2(0, 1);
             headerRT.anchorMax = new Vector2(1, 1);
             headerRT.pivot = new Vector2(0.5f, 1);
-            headerRT.anchoredPosition = new Vector2(0, 20);
+            headerRT.anchoredPosition = new Vector2(0, 0);
             headerRT.sizeDelta = new Vector2(0, 30);
             header.GetComponent<Image>().color = new Color(0.4f, 0.2f, 0.3f, 0.9f);
 
@@ -109,9 +110,14 @@ namespace ONI_MP.UI
             contentsRT.offsetMin = new Vector2(0, 0);
             contentsRT.offsetMax = new Vector2(0, -30);
 
-            var panel = CreatePanel("ChatPanel", chatboxContents.transform, new Vector2(400, 200));
+            var panel = new GameObject("ChatPanel", typeof(Image));
+            panel.transform.SetParent(chatboxContents.transform, false);
             panel.GetComponent<Image>().color = new Color(0, 0, 0, 0.7f);
             panelRectTransform = panel.GetComponent<RectTransform>();
+            panelRectTransform.anchorMin = Vector2.zero;
+            panelRectTransform.anchorMax = Vector2.one;
+            panelRectTransform.offsetMin = Vector2.zero;
+            panelRectTransform.offsetMax = Vector2.zero;
 
             var scroll = CreateScrollArea("Scroll", panel.transform, out messageContainer);
             var scrollRT = scroll.GetComponent<RectTransform>();
@@ -128,6 +134,10 @@ namespace ONI_MP.UI
             messageContainer.pivot = new Vector2(0.5f, 1f);
 
             inputField = CreateInputField("ChatInput", panel.transform, new Vector2(10, 15), new Vector2(380, 30));
+            var inputRT = inputField.GetComponent<RectTransform>();
+            inputRT.anchorMax = new Vector2(1, 0);
+            inputRT.offsetMin = new Vector2(10, 15);
+            inputRT.offsetMax = new Vector2(-10, 45);
             inputField.onEndEdit.AddListener(OnInputSubmitted);
 
             var headerTextGO = new GameObject("HeaderText", typeof(TextMeshProUGUI));
@@ -157,6 +167,15 @@ namespace ONI_MP.UI
             });
 
             header.transform.SetAsLastSibling();
+
+            resizeHandles = new GameObject("ResizeHandles", typeof(RectTransform));
+            resizeHandles.transform.SetParent(chatWindowRoot.transform, false);
+            var resizeRT = resizeHandles.GetComponent<RectTransform>();
+            resizeRT.anchorMin = Vector2.zero;
+            resizeRT.anchorMax = Vector2.one;
+            resizeRT.offsetMin = Vector2.zero;
+            resizeRT.offsetMax = Vector2.zero;
+            CreateResizeHandles(resizeHandles.transform, rootRT);
 
             PendingMessage init_message = GeneratePendingMessage(STRINGS.UI.MP_CHATWINDOW.CHAT_INITIALIZED);
             QueueMessage(init_message);
@@ -287,6 +306,7 @@ namespace ONI_MP.UI
 
 			header.SetActive(MultiplayerSession.InSession);
 			chatbox.SetActive(MultiplayerSession.InSession && expanded);
+			resizeHandles.SetActive(MultiplayerSession.InSession && expanded);
 			if (!MultiplayerSession.InSession)
 			{
 				return;
@@ -487,6 +507,63 @@ namespace ONI_MP.UI
 			};
 			return pendingMessage;
         }
+        private void CreateResizeHandles(Transform parent, RectTransform target)
+		{
+			using var _ = Profiler.Scope();
+
+			float halfThick = 4f;
+			float cornerSize = 12f;
+
+			CreateHandle(parent, target, ResizeEdge.Top,
+				new Vector2(0, 1), new Vector2(1, 1), new Vector2(0.5f, 0.5f),
+				new Vector2(0, -halfThick), new Vector2(0, halfThick));
+			CreateHandle(parent, target, ResizeEdge.Bottom,
+				new Vector2(0, 0), new Vector2(1, 0), new Vector2(0.5f, 0.5f),
+				new Vector2(0, -halfThick), new Vector2(0, halfThick));
+			CreateHandle(parent, target, ResizeEdge.Left,
+				new Vector2(0, 0), new Vector2(0, 1), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfThick, 0), new Vector2(halfThick, 0));
+			CreateHandle(parent, target, ResizeEdge.Right,
+				new Vector2(1, 0), new Vector2(1, 1), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfThick, 0), new Vector2(halfThick, 0));
+
+			float halfCorner = cornerSize * 0.5f;
+			CreateHandle(parent, target, ResizeEdge.Top | ResizeEdge.Left,
+				new Vector2(0, 1), new Vector2(0, 1), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfCorner, -halfCorner), new Vector2(halfCorner, halfCorner));
+			CreateHandle(parent, target, ResizeEdge.Top | ResizeEdge.Right,
+				new Vector2(1, 1), new Vector2(1, 1), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfCorner, -halfCorner), new Vector2(halfCorner, halfCorner));
+			CreateHandle(parent, target, ResizeEdge.Bottom | ResizeEdge.Left,
+				new Vector2(0, 0), new Vector2(0, 0), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfCorner, -halfCorner), new Vector2(halfCorner, halfCorner));
+			CreateHandle(parent, target, ResizeEdge.Bottom | ResizeEdge.Right,
+				new Vector2(1, 0), new Vector2(1, 0), new Vector2(0.5f, 0.5f),
+				new Vector2(-halfCorner, -halfCorner), new Vector2(halfCorner, halfCorner));
+		}
+
+		private void CreateHandle(Transform parent, RectTransform target, ResizeEdge edges,
+			Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot,
+			Vector2 offsetMin, Vector2 offsetMax)
+		{
+			var go = new GameObject($"ResizeHandle_{edges}", typeof(RectTransform), typeof(Image));
+			go.transform.SetParent(parent, false);
+
+			var rt = go.GetComponent<RectTransform>();
+			rt.anchorMin = anchorMin;
+			rt.anchorMax = anchorMax;
+			rt.pivot = pivot;
+			rt.offsetMin = offsetMin;
+			rt.offsetMax = offsetMax;
+
+			var img = go.GetComponent<Image>();
+			img.color = Color.clear;
+
+			var handle = go.AddComponent<UIResizeHandle>();
+			handle.target = target;
+			handle.edges = edges;
+		}
+
         public void Clamp(Vector2 position, RectTransform target)
 		{
 			Vector2 newPos = position;

--- a/ClassLibrary1/Menus/ChatScreen.cs
+++ b/ClassLibrary1/Menus/ChatScreen.cs
@@ -134,6 +134,9 @@ namespace ONI_MP.UI
             expanded = true;
             header.GetComponent<Button>().onClick.AddListener(() =>
             {
+                if (drag.WasDragged)
+                    return;
+
                 expanded = !expanded;
                 chatbox.SetActive(expanded);
                 headerText.text = expanded ? STRINGS.UI.MP_CHATWINDOW.RESIZE.RETRACT : STRINGS.UI.MP_CHATWINDOW.RESIZE.EXPAND;

--- a/ClassLibrary1/Networking/Components/UIDragHandler.cs
+++ b/ClassLibrary1/Networking/Components/UIDragHandler.cs
@@ -6,6 +6,7 @@ using UnityEngine.EventSystems;
 public class UIDragHandler : MonoBehaviour, IPointerDownHandler, IDragHandler
 {
     [SerializeField] public RectTransform target;
+    public bool WasDragged { get; private set; }
 
     private Vector2 offset;
 
@@ -23,6 +24,7 @@ public class UIDragHandler : MonoBehaviour, IPointerDownHandler, IDragHandler
 
         RectTransform parent = target.parent as RectTransform;
 
+        WasDragged = false;
         RectTransformUtility.ScreenPointToLocalPointInRectangle(parent, eventData.position, eventData.pressEventCamera, out Vector2 localMousePosition);
         offset = target.anchoredPosition - localMousePosition;
     }
@@ -34,6 +36,7 @@ public class UIDragHandler : MonoBehaviour, IPointerDownHandler, IDragHandler
         if (target == null)
             return;
 
+        WasDragged = true;
         RectTransform parent = target.parent as RectTransform;
 
         if (RectTransformUtility.ScreenPointToLocalPointInRectangle(parent, eventData.position, eventData.pressEventCamera, out Vector2 localMousePosition))

--- a/ClassLibrary1/Networking/Components/UIDragHandler.cs
+++ b/ClassLibrary1/Networking/Components/UIDragHandler.cs
@@ -46,13 +46,11 @@ public class UIDragHandler : MonoBehaviour, IPointerDownHandler, IDragHandler
             // Clamp to parent/canvas bounds
             RectTransform canvasRect = GameScreenManager.Instance.ssOverlayCanvas.GetComponent<RectTransform>();
 
-            float halfWidth = target.rect.width * 0.5f;
-            float halfHeight = target.rect.height * 0.5f;
-
-            float leftLimit = -canvasRect.rect.width * 0.5f + halfWidth;
-            float rightLimit = canvasRect.rect.width * 0.5f - halfWidth;
-            float bottomLimit = -canvasRect.rect.height * 0.5f + halfHeight;
-            float topLimit = canvasRect.rect.height * 0.5f - halfHeight;
+            float padding = 10f;
+            float leftLimit = -canvasRect.rect.width * 0.5f + target.rect.width * target.pivot.x + padding;
+            float rightLimit = canvasRect.rect.width * 0.5f - target.rect.width * (1f - target.pivot.x) - padding;
+            float bottomLimit = -canvasRect.rect.height * 0.5f + target.rect.height * target.pivot.y + padding;
+            float topLimit = canvasRect.rect.height * 0.5f - target.rect.height * (1f - target.pivot.y) - padding;
 
             newPos.x = Mathf.Clamp(newPos.x, leftLimit, rightLimit);
             newPos.y = Mathf.Clamp(newPos.y, bottomLimit, topLimit);

--- a/ClassLibrary1/Networking/Components/UIResizeHandle.cs
+++ b/ClassLibrary1/Networking/Components/UIResizeHandle.cs
@@ -1,0 +1,116 @@
+using System;
+using Shared.Profiling;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+[Flags]
+public enum ResizeEdge
+{
+	None = 0,
+	Left = 1,
+	Right = 2,
+	Top = 4,
+	Bottom = 8,
+}
+
+public class UIResizeHandle : MonoBehaviour, IPointerDownHandler, IDragHandler, IPointerEnterHandler, IPointerExitHandler
+{
+	public RectTransform target;
+	public ResizeEdge edges;
+	public Vector2 minSize = new Vector2(200, 120);
+	public Vector2 maxSize = new Vector2(800, 600);
+
+	private Vector2 dragStart;
+	private Vector2 startSize;
+	private Vector2 startPos;
+	private Image image;
+
+	private static readonly Color hoverColor = new Color(1f, 1f, 1f, 0.25f);
+
+	private void Awake()
+	{
+		using var _ = Profiler.Scope();
+
+		image = GetComponent<Image>();
+	}
+
+	public void OnPointerEnter(PointerEventData eventData)
+	{
+		using var _ = Profiler.Scope();
+
+		if (image != null)
+			image.color = hoverColor;
+	}
+
+	public void OnPointerExit(PointerEventData eventData)
+	{
+		using var _ = Profiler.Scope();
+
+		if (image != null)
+			image.color = Color.clear;
+	}
+
+	public void OnPointerDown(PointerEventData eventData)
+	{
+		using var _ = Profiler.Scope();
+
+		RectTransformUtility.ScreenPointToLocalPointInRectangle(
+			target.parent as RectTransform, eventData.position, eventData.pressEventCamera, out dragStart);
+		startSize = target.sizeDelta;
+		startPos = target.anchoredPosition;
+	}
+
+	public void OnDrag(PointerEventData eventData)
+	{
+		using var _ = Profiler.Scope();
+
+		if (target == null)
+			return;
+
+		RectTransform parent = target.parent as RectTransform;
+		if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(parent, eventData.position, eventData.pressEventCamera, out Vector2 current))
+			return;
+
+		Vector2 delta = current - dragStart;
+		Vector2 newSize = startSize;
+		Vector2 newPos = startPos;
+
+		if ((edges & ResizeEdge.Right) != 0)
+		{
+			newSize.x = startSize.x + delta.x;
+			newPos.x = startPos.x + delta.x * 0.5f;
+		}
+		else if ((edges & ResizeEdge.Left) != 0)
+		{
+			newSize.x = startSize.x - delta.x;
+			newPos.x = startPos.x + delta.x * 0.5f;
+		}
+
+		if ((edges & ResizeEdge.Top) != 0)
+		{
+			newSize.y = startSize.y + delta.y;
+		}
+		else if ((edges & ResizeEdge.Bottom) != 0)
+		{
+			newSize.y = startSize.y - delta.y;
+			newPos.y = startPos.y + delta.y;
+		}
+
+		Vector2 clampedSize = new Vector2(
+			Mathf.Clamp(newSize.x, minSize.x, maxSize.x),
+			Mathf.Clamp(newSize.y, minSize.y, maxSize.y));
+
+		if ((edges & ResizeEdge.Right) != 0)
+			newPos.x = startPos.x + (clampedSize.x - startSize.x) * 0.5f;
+		else if ((edges & ResizeEdge.Left) != 0)
+			newPos.x = startPos.x - (clampedSize.x - startSize.x) * 0.5f;
+
+		if ((edges & ResizeEdge.Bottom) != 0)
+			newPos.y = startPos.y - (clampedSize.y - startSize.y);
+
+		target.sizeDelta = clampedSize;
+		target.anchoredPosition = newPos;
+	}
+
+}

--- a/ClassLibrary1/Networking/Packets/Social/ChatHistorySyncPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Social/ChatHistorySyncPacket.cs
@@ -1,0 +1,66 @@
+using ONI_MP.UI;
+using System.Collections.Generic;
+using System.IO;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking.Packets.Social
+{
+	public class ChatHistorySyncPacket : IPacket
+	{
+		public List<ChatScreen.PendingMessage> Messages = new List<ChatScreen.PendingMessage>();
+
+		public ChatHistorySyncPacket()
+		{
+		}
+
+		public ChatHistorySyncPacket(List<ChatScreen.PendingMessage> messages)
+		{
+			using var _ = Profiler.Scope();
+
+			Messages = messages;
+		}
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write(Messages.Count);
+			foreach (var msg in Messages)
+			{
+				writer.Write(msg.timestamp);
+				writer.Write(msg.message);
+			}
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			int count = reader.ReadInt32();
+			Messages = new List<ChatScreen.PendingMessage>(count);
+			for (int i = 0; i < count; i++)
+			{
+				Messages.Add(new ChatScreen.PendingMessage
+				{
+					timestamp = reader.ReadInt64(),
+					message = reader.ReadString()
+				});
+			}
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (ChatScreen.Instance != null)
+				ChatScreen.Instance.ClearMessages();
+
+			var initMsg = ChatScreen.GeneratePendingMessage(STRINGS.UI.MP_CHATWINDOW.CHAT_INITIALIZED);
+			ChatScreen.QueueMessage(initMsg);
+
+			foreach (var msg in Messages)
+				ChatScreen.QueueMessage(msg);
+		}
+	}
+}

--- a/ClassLibrary1/STRINGS.cs
+++ b/ClassLibrary1/STRINGS.cs
@@ -205,7 +205,7 @@ namespace ONI_MP
 			}
 			public class MP_CHATWINDOW
 			{
-				public static LocString CHAT_INITIALIZED = "<color=yellow>[System]:</color> Chat initialized.";
+				public static LocString CHAT_INITIALIZED = "<color=yellow>[System]</color> Chat initialized.";
 				public static LocString CHAT_CLIENT_REJECTED = "<color=red>[System]</color> {0} was rejected due to mod incompatibility: {1}";
 				public static LocString CHAT_CLIENT_JOINED = "<color=yellow>[System]</color> <b>{0}</b> joined the game.";
 				public static LocString CHAT_CLIENT_LEFT = "<color=yellow>[System]</color> <b>{0}</b> left the game.";


### PR DESCRIPTION
- Dragging the header no longer toggles the chatbox open/closed
- Clamping is now pivot-aware and the start position scales with resolution
- New clients receive the host's chat history on join
- Fixed zoom input bleeding through when scrolling in the chat panel
- Chat window can be resized from all edges and corners with visual hover feedback
- Consistent system message formatting (removed stray colon)
- Added vertical scrollbar to chat message area