### PR TITLE
sync improvements

### DIFF
--- a/ClassLibrary1/DebugTools/SyncStats.cs
+++ b/ClassLibrary1/DebugTools/SyncStats.cs
@@ -32,6 +32,7 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric Buildings = new SyncMetric { Name = "Buildings", Interval = 30f };
 		public static SyncMetric Structures = new SyncMetric { Name = "Structures", Interval = 0.5f };
 		public static SyncMetric VitalStats = new SyncMetric { Name = "VitalStats", Interval = 1f };
+		public static SyncMetric Plants = new SyncMetric { Name = "Plants", Interval = 5f };
 
 		/// <summary>
 		/// Updates a metric after a sync operation.
@@ -52,7 +53,7 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric[] AllMetrics => new[]
 		{
 			Gas, Digging, Chores, Research,
-			Buildings, Structures, VitalStats
+			Buildings, Structures, VitalStats, Plants
 		};
 	}
 }

--- a/ClassLibrary1/MultiplayerMod.cs
+++ b/ClassLibrary1/MultiplayerMod.cs
@@ -72,6 +72,7 @@ namespace ONI_MP
 				go.AddComponent<PingManager>();
 				go.AddComponent<BuildingSyncer>();
 				go.AddComponent<WorldStateSyncer>();
+				go.AddComponent<PlantGrowthSyncer>();
 				go.AddComponent<BulkPacketMonitor>();
 
 				// CHECKPOINT 5

--- a/ClassLibrary1/Networking/Components/NetworkIdentity.cs
+++ b/ClassLibrary1/Networking/Components/NetworkIdentity.cs
@@ -105,6 +105,7 @@ namespace ONI_MP.Networking.Components
 		{
 			using var _ = Profiler.Scope();
 
+			RemoteProgressRegistry.Clear(NetId);
 			NetworkIdentityRegistry.Unregister(NetId);
 			DebugConsole.Log($"[NetworkIdentity] Unregistered NetId {NetId} for {gameObject.name}");
 			base.OnCleanUp();

--- a/ClassLibrary1/Networking/Components/PlantGrowthSyncer.cs
+++ b/ClassLibrary1/Networking/Components/PlantGrowthSyncer.cs
@@ -1,0 +1,593 @@
+using ONI_MP.DebugTools;
+using ONI_MP.Networking.Packets.World;
+using ONI_MP.Networking.Trackers;
+using Shared.Profiling;
+using System.Collections.Generic;
+using UnityEngine;
+using Shared.Interfaces.Networking;
+
+namespace ONI_MP.Networking.Components
+{
+	public class PlantGrowthSyncer : MonoBehaviour
+	{
+		public static PlantGrowthSyncer Instance { get; private set; }
+
+		public static bool IsApplyingState = false;
+
+		private const float SYNC_INTERVAL = 5f;
+		private const float INITIAL_DELAY = 7f;
+		private const float LIVE_EVENT_DELAY = 2f;
+
+		private float _lastSyncTime;
+		private bool _initialized;
+		private float _initializationTime;
+
+		private void Awake()
+		{
+			using var _ = Profiler.Scope();
+
+			Instance = this;
+		}
+
+		public static bool CanBroadcastLifecycleEvents =>
+			Instance != null &&
+			Instance._initialized &&
+			Time.unscaledTime - Instance._initializationTime >= LIVE_EVENT_DELAY &&
+			MultiplayerSession.InSession &&
+			MultiplayerSession.IsHost &&
+			MultiplayerSession.ConnectedPlayers.Count > 0 &&
+			!GameServerHardSync.IsHardSyncInProgress;
+
+		private void Update()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.InSession || !MultiplayerSession.IsHost)
+				return;
+
+			if (MultiplayerSession.ConnectedPlayers.Count == 0)
+				return;
+
+			if (!_initialized)
+			{
+				_initializationTime = Time.unscaledTime;
+				_initialized = true;
+				return;
+			}
+
+			if (Time.unscaledTime - _initializationTime < INITIAL_DELAY)
+				return;
+
+			if (Time.unscaledTime - _lastSyncTime <= SYNC_INTERVAL)
+				return;
+
+			_lastSyncTime = Time.unscaledTime;
+			SendPlantStates();
+		}
+
+		public static void BroadcastPlantLifecycle(PlantLifecycleOperation operation, Growing growing, SingleEntityReceptacle receptacleOverride = null)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!CanBroadcastLifecycleEvents)
+				return;
+
+			if (!TryBuildPlantData(growing, out var data, receptacleOverride))
+				return;
+
+			PacketSender.SendToAllClients(new PlantLifecyclePacket
+			{
+				Operation = operation,
+				Plant = data
+			});
+		}
+
+		public static bool TryBuildPlantData(Growing growing, out PlantData data, SingleEntityReceptacle receptacleOverride = null)
+		{
+			using var _ = Profiler.Scope();
+
+			data = default;
+
+			if (growing == null || growing.gameObject == null)
+				return false;
+
+			int cell = Grid.PosToCell(growing.gameObject);
+			if (!Grid.IsValidCell(cell))
+				return false;
+
+			if (!growing.TryGetComponent<KPrefabID>(out var kpid) || kpid == null)
+				return false;
+
+			int plantNetId = EnsureIdentity(growing.gameObject, 0);
+			int receptacleNetId = 0;
+			bool isWild = growing.IsWildPlanted();
+
+			var receptacle = receptacleOverride;
+			if (receptacle == null)
+			{
+				TryGetReceptacle(growing, out receptacle);
+			}
+
+			if (receptacle != null && receptacle.gameObject != null)
+			{
+				receptacleNetId = EnsureIdentity(receptacle.gameObject, 0);
+				isWild = false;
+			}
+
+			bool isWilting = false;
+			if (growing.TryGetComponent<WiltCondition>(out var wiltCondition) && wiltCondition != null)
+			{
+				isWilting = wiltCondition.IsWilting();
+			}
+
+			bool isHarvestReady = false;
+			if (growing.TryGetComponent<HarvestDesignatable>(out var harvestDesignatable) && harvestDesignatable != null)
+			{
+				isHarvestReady = harvestDesignatable.CanBeHarvested();
+			}
+
+			data = new PlantData
+			{
+				PlantNetId = plantNetId,
+				ReceptacleNetId = receptacleNetId,
+				Cell = cell,
+				PlantPrefabTag = kpid.PrefabTag.Name,
+				Maturity = growing.PercentGrown(),
+				IsWilting = isWilting,
+				IsHarvestReady = isHarvestReady,
+				IsWild = isWild
+			};
+			return true;
+		}
+
+		private void SendPlantStates()
+		{
+			using var _ = Profiler.Scope();
+
+			var sw = System.Diagnostics.Stopwatch.StartNew();
+			var packet = new PlantGrowthStatePacket();
+
+			lock (PlantTracker.AllPlants)
+			{
+				foreach (var growing in PlantTracker.AllPlants)
+				{
+					if (!TryBuildPlantData(growing, out var data))
+						continue;
+
+					packet.Plants.Add(data);
+				}
+			}
+
+			PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
+
+			sw.Stop();
+			SyncStats.RecordSync(SyncStats.Plants, packet.Plants.Count, packet.Plants.Count * 48, sw.ElapsedMilliseconds);
+		}
+
+		public bool OnPlantLifecycleReceived(PlantLifecyclePacket packet)
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost || Grid.WidthInCells == 0)
+				return false;
+
+			try
+			{
+				IsApplyingState = true;
+				return packet.Operation switch
+				{
+					PlantLifecycleOperation.Spawn => SpawnOrUpdatePlant(packet.Plant),
+					PlantLifecycleOperation.Remove => RemovePlant(packet.Plant),
+					_ => false
+				};
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[PlantGrowthSyncer] Error applying lifecycle packet {packet.Operation}: {ex.Message}");
+				return false;
+			}
+			finally
+			{
+				IsApplyingState = false;
+			}
+		}
+
+		public void OnPlantStateReceived(PlantGrowthStatePacket packet)
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost || Grid.WidthInCells == 0)
+				return;
+
+			try
+			{
+				IsApplyingState = true;
+
+				var remoteByPlantId = new Dictionary<int, PlantData>();
+				var remoteByReceptacleId = new Dictionary<int, PlantData>();
+				var remoteByCell = new Dictionary<int, PlantData>();
+
+				foreach (var plant in packet.Plants)
+				{
+					if (plant.PlantNetId != 0)
+						remoteByPlantId[plant.PlantNetId] = plant;
+					if (plant.ReceptacleNetId != 0)
+						remoteByReceptacleId[plant.ReceptacleNetId] = plant;
+					if (Grid.IsValidCell(plant.Cell))
+						remoteByCell[plant.Cell] = plant;
+				}
+
+				var matchedPlantIds = new HashSet<int>();
+				var matchedReceptacleIds = new HashSet<int>();
+				var matchedCells = new HashSet<int>();
+				var toRemove = new List<Growing>();
+
+				lock (PlantTracker.AllPlants)
+				{
+					foreach (var growing in PlantTracker.AllPlants)
+					{
+						if (growing == null)
+							continue;
+
+						if (TryFindMatchingRemote(growing, remoteByPlantId, remoteByReceptacleId, remoteByCell, out var remoteData))
+						{
+							if (remoteData.PlantNetId != 0)
+								matchedPlantIds.Add(remoteData.PlantNetId);
+							if (remoteData.ReceptacleNetId != 0)
+								matchedReceptacleIds.Add(remoteData.ReceptacleNetId);
+							if (Grid.IsValidCell(remoteData.Cell))
+								matchedCells.Add(remoteData.Cell);
+
+							ApplyPlantState(growing, remoteData);
+							continue;
+						}
+
+						toRemove.Add(growing);
+					}
+				}
+
+				foreach (var growing in toRemove)
+				{
+					if (growing == null || growing.gameObject == null)
+						continue;
+
+					DebugConsole.Log($"[PlantGrowthSyncer] Removing phantom plant at {Grid.PosToCell(growing)}");
+					Util.KDestroyGameObject(growing.gameObject);
+				}
+
+				foreach (var plant in packet.Plants)
+				{
+					if (plant.PlantNetId != 0 && matchedPlantIds.Contains(plant.PlantNetId))
+						continue;
+					if (plant.PlantNetId == 0 && plant.ReceptacleNetId != 0 && matchedReceptacleIds.Contains(plant.ReceptacleNetId))
+						continue;
+					if (plant.PlantNetId == 0 && plant.ReceptacleNetId == 0 && matchedCells.Contains(plant.Cell))
+						continue;
+
+					SpawnOrUpdatePlant(plant);
+				}
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[PlantGrowthSyncer] Error in OnPlantStateReceived: {ex.Message}");
+			}
+			finally
+			{
+				IsApplyingState = false;
+			}
+		}
+
+		private static bool TryFindMatchingRemote(
+			Growing growing,
+			Dictionary<int, PlantData> remoteByPlantId,
+			Dictionary<int, PlantData> remoteByReceptacleId,
+			Dictionary<int, PlantData> remoteByCell,
+			out PlantData data)
+		{
+			using var _ = Profiler.Scope();
+
+			data = default;
+
+			int plantNetId = GetExistingIdentityId(growing.gameObject);
+			if (plantNetId != 0 && remoteByPlantId.TryGetValue(plantNetId, out data))
+				return true;
+
+			if (TryGetReceptacle(growing, out var receptacle))
+			{
+				int receptacleNetId = GetExistingIdentityId(receptacle.gameObject);
+				if (receptacleNetId != 0 && remoteByReceptacleId.TryGetValue(receptacleNetId, out data))
+					return true;
+			}
+
+			int cell = Grid.PosToCell(growing.gameObject);
+			return Grid.IsValidCell(cell) && remoteByCell.TryGetValue(cell, out data);
+		}
+
+		private bool SpawnOrUpdatePlant(PlantData data)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!Grid.IsValidCell(data.Cell) || string.IsNullOrEmpty(data.PlantPrefabTag))
+				return false;
+
+			if (TryFindLocalPlant(data, out var existingPlant))
+			{
+				ApplyPlantState(existingPlant, data);
+				return true;
+			}
+
+			var receptacle = ResolveReceptacle(data);
+			if (receptacle != null && receptacle.Occupant != null && receptacle.Occupant.TryGetComponent<Growing>(out var occupantPlant))
+			{
+				bool samePlant = GetExistingIdentityId(occupantPlant.gameObject) == data.PlantNetId;
+				if (!samePlant &&
+					occupantPlant.TryGetComponent<KPrefabID>(out var occupantKpid) &&
+					occupantKpid != null &&
+					string.Equals(occupantKpid.PrefabTag.Name, data.PlantPrefabTag))
+				{
+					samePlant = true;
+				}
+
+				if (samePlant)
+				{
+					ApplyPlantState(occupantPlant, data);
+					return true;
+				}
+
+				Util.KDestroyGameObject(receptacle.Occupant);
+			}
+
+			var prefab = Assets.GetPrefab(new Tag(data.PlantPrefabTag));
+			if (prefab == null)
+			{
+				DebugConsole.LogWarning($"[PlantGrowthSyncer] Could not find prefab for plant '{data.PlantPrefabTag}'");
+				return false;
+			}
+
+			Vector3 pos = Grid.CellToPosCBC(data.Cell, Grid.SceneLayer.BuildingFront);
+			GameObject plantGo = Util.KInstantiate(prefab, pos);
+			if (plantGo == null)
+				return false;
+
+			plantGo.SetActive(true);
+			EnsureIdentity(plantGo, data.PlantNetId);
+
+			if (receptacle is PlantablePlot plot)
+			{
+				plot.ReplacePlant(plantGo, true);
+
+				if (plantGo.TryGetComponent<ReceptacleMonitor>(out var rm) && rm != null)
+				{
+					rm.SetReceptacle(plot);
+				}
+			}
+			else if (receptacle != null)
+			{
+				receptacle.CancelActiveRequest();
+				receptacle.ForceDeposit(plantGo);
+			}
+
+			if (!TryFindLocalPlant(data, out var spawnedPlant))
+			{
+				spawnedPlant = plantGo.GetComponent<Growing>();
+			}
+
+			if (spawnedPlant == null)
+			{
+				DebugConsole.LogWarning($"[PlantGrowthSyncer] Spawned plant '{data.PlantPrefabTag}' but could not resolve Growing at cell {data.Cell}");
+				return false;
+			}
+
+			ApplyPlantState(spawnedPlant, data);
+
+			DebugConsole.Log(receptacle != null
+				? $"[PlantGrowthSyncer] Spawned planted crop '{data.PlantPrefabTag}' at cell {data.Cell} for receptacle {data.ReceptacleNetId}"
+				: $"[PlantGrowthSyncer] Spawned wild plant '{data.PlantPrefabTag}' at cell {data.Cell}");
+
+			return true;
+		}
+
+		private bool RemovePlant(PlantData data)
+		{
+			using var _ = Profiler.Scope();
+
+			if (TryFindLocalPlant(data, out var growing) && growing != null && growing.gameObject != null)
+			{
+				Util.KDestroyGameObject(growing.gameObject);
+				DebugConsole.Log($"[PlantGrowthSyncer] Removed plant '{data.PlantPrefabTag}' at cell {data.Cell}");
+				return true;
+			}
+
+			var receptacle = ResolveReceptacle(data);
+			if (receptacle?.Occupant != null)
+			{
+				Util.KDestroyGameObject(receptacle.Occupant);
+				DebugConsole.Log($"[PlantGrowthSyncer] Removed receptacle occupant for plant '{data.PlantPrefabTag}' at cell {data.Cell}");
+				return true;
+			}
+
+			return false;
+		}
+
+		private static bool TryFindLocalPlant(PlantData data, out Growing growing)
+		{
+			using var _ = Profiler.Scope();
+
+			growing = null;
+
+			if (data.PlantNetId != 0 && NetworkIdentityRegistry.TryGetComponent(data.PlantNetId, out Growing byId) && byId != null)
+			{
+				growing = byId;
+				return true;
+			}
+
+			if (data.ReceptacleNetId != 0 &&
+				NetworkIdentityRegistry.TryGet(data.ReceptacleNetId, out var receptacleIdentity) &&
+				receptacleIdentity != null &&
+				receptacleIdentity.gameObject.TryGetComponent<SingleEntityReceptacle>(out var receptacle) &&
+				receptacle.Occupant != null &&
+				receptacle.Occupant.TryGetComponent<Growing>(out var byReceptacle) &&
+				byReceptacle != null)
+			{
+				growing = byReceptacle;
+				return true;
+			}
+
+			lock (PlantTracker.AllPlants)
+			{
+				foreach (var trackedPlant in PlantTracker.AllPlants)
+				{
+					if (trackedPlant == null || trackedPlant.gameObject == null)
+						continue;
+
+					int cell = Grid.PosToCell(trackedPlant.gameObject);
+					if (cell != data.Cell)
+						continue;
+
+					if (!trackedPlant.TryGetComponent<KPrefabID>(out var kpid) || kpid == null)
+						continue;
+
+					if (!string.Equals(kpid.PrefabTag.Name, data.PlantPrefabTag))
+						continue;
+
+					growing = trackedPlant;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static SingleEntityReceptacle ResolveReceptacle(PlantData data)
+		{
+			using var _ = Profiler.Scope();
+
+			if (data.ReceptacleNetId != 0 &&
+				NetworkIdentityRegistry.TryGet(data.ReceptacleNetId, out var receptacleIdentity) &&
+				receptacleIdentity != null &&
+				receptacleIdentity.gameObject.TryGetComponent<SingleEntityReceptacle>(out var byId))
+			{
+				return byId;
+			}
+
+			if (!Grid.IsValidCell(data.Cell))
+				return null;
+
+			ObjectLayer[] layersToCheck =
+			{
+				ObjectLayer.Building,
+				ObjectLayer.FoundationTile,
+				ObjectLayer.Plants,
+				ObjectLayer.AttachableBuilding,
+			};
+
+			foreach (var layer in layersToCheck)
+			{
+				var obj = Grid.Objects[data.Cell, (int)layer];
+				if (obj != null && obj.TryGetComponent<SingleEntityReceptacle>(out var receptacle))
+					return receptacle;
+			}
+
+			return null;
+		}
+
+		private static bool TryGetReceptacle(Growing growing, out SingleEntityReceptacle receptacle)
+		{
+			using var _ = Profiler.Scope();
+
+			receptacle = null;
+			if (growing == null || growing.gameObject == null)
+				return false;
+
+			if (growing.TryGetComponent<ReceptacleMonitor>(out var rm) && rm != null)
+			{
+				receptacle = rm.GetReceptacle();
+				if (receptacle != null)
+					return true;
+			}
+
+			receptacle = growing.GetComponentInParent<SingleEntityReceptacle>();
+			return receptacle != null;
+		}
+
+		private static int EnsureIdentity(GameObject go, int targetNetId)
+		{
+			using var _ = Profiler.Scope();
+
+			if (go == null)
+				return 0;
+
+			var identity = go.AddOrGet<NetworkIdentity>();
+			if (identity.NetId == 0)
+			{
+				identity.RegisterIdentity();
+			}
+
+			if (targetNetId != 0 && identity.NetId != targetNetId)
+			{
+				identity.OverrideNetId(targetNetId);
+			}
+
+			return identity.NetId;
+		}
+
+		private static int GetExistingIdentityId(GameObject go)
+		{
+			using var _ = Profiler.Scope();
+
+			if (go == null || !go.TryGetComponent<NetworkIdentity>(out var identity) || identity == null)
+				return 0;
+
+			return identity.NetId;
+		}
+
+		private static void ApplyPlantState(Growing growing, PlantData data)
+		{
+			using var _ = Profiler.Scope();
+
+			if (growing == null || growing.gameObject == null)
+				return;
+
+			try
+			{
+				EnsureIdentity(growing.gameObject, data.PlantNetId);
+
+				float currentMaturity = growing.PercentGrown();
+				if (Mathf.Abs(currentMaturity - data.Maturity) > 0.001f)
+				{
+					growing.OverrideMaturityLevel(data.Maturity);
+				}
+
+				if (!data.IsWild && TryGetReceptacle(growing, out var receptacle) && receptacle is PlantablePlot plot)
+				{
+					if (growing.TryGetComponent<ReceptacleMonitor>(out var rm) && rm != null)
+					{
+						rm.SetReceptacle(plot);
+					}
+				}
+
+				if (growing.TryGetComponent<WiltCondition>(out var wiltCondition) && wiltCondition != null)
+				{
+					if (data.IsWilting && !wiltCondition.IsWilting())
+					{
+						wiltCondition.DoWilt();
+					}
+					else if (!data.IsWilting && wiltCondition.IsWilting())
+					{
+						wiltCondition.DoRecover();
+					}
+				}
+
+				if (growing.TryGetComponent<KBatchedAnimController>(out var kbac) && kbac != null)
+				{
+					kbac.SetVisiblity(true);
+					kbac.forceRebuild = true;
+				}
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[PlantGrowthSyncer] Error applying plant state at cell {data.Cell}: {ex.Message}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/GameClient.cs
+++ b/ClassLibrary1/Networking/GameClient.cs
@@ -102,7 +102,7 @@ namespace ONI_MP.Networking
 			NetworkConfig.TransportClient.OnReturnToMenu = (reason, message) => CoroutineRunner.RunOne(ShowMessageAndReturnToTitle(reason, message));
 			NetworkConfig.TransportClient.OnRequestStateOrReturn = () =>
 			{
-                PacketSender.SendToHost(new GameStateRequestPacket(MultiplayerSession.LocalUserID));
+                PacketSender.SendToHost(GameStateRequestPacket.CreateClientRequest(MultiplayerSession.LocalUserID));
                 MP_Timer.Instance.StartDelayedAction(10, () => CoroutineRunner.RunOne(ShowMessageAndReturnToTitle()));
             };
             NetworkConfig.TransportClient.Prepare();
@@ -178,6 +178,19 @@ namespace ONI_MP.Networking
 
 			DebugConsole.Log("Gamestate packet received");
 			MP_Timer.Instance.Abort();
+			if (!TryValidateHostProtocol(packet, out string protocolReason, out string protocolMessage))
+			{
+				DebugConsole.LogWarning($"[GameClient] Host protocol validation failed: {protocolReason} | {protocolMessage}");
+				Disconnect();
+				NetworkConfig.TransportClient.OnReturnToMenu.Invoke(protocolReason, protocolMessage);
+				return;
+			}
+
+			if (MultiplayerSession.GetPlayer(MultiplayerSession.HostUserID) is MultiplayerPlayer host)
+			{
+				host.ProtocolVerified = true;
+			}
+
 			if (!SaveHelper.SavegameDlcListValid(packet.ActiveDlcIds, out var errorMsg))
 			{
 				DebugConsole.Log("invalid dlc config detected");
@@ -208,6 +221,42 @@ namespace ONI_MP.Networking
 			}
 
 			ContinueConnectionFlow();
+		}
+
+		private static bool TryValidateHostProtocol(GameStateRequestPacket packet, out string reason, out string message)
+		{
+			using var _ = Profiler.Scope();
+
+			reason = "Protocol mismatch";
+			message = string.Empty;
+
+			if (!packet.HasProtocolMetadata)
+			{
+				message = "The host is running a build without protocol metadata. Update both peers to the same build.";
+				return false;
+			}
+
+			if (!packet.ProtocolAccepted)
+			{
+				message = string.IsNullOrEmpty(packet.ProtocolFailureReason)
+					? "The host rejected this client due to an incompatible network protocol."
+					: packet.ProtocolFailureReason;
+				return false;
+			}
+
+			if (packet.ProtocolVersion != ProtocolCompatibility.CurrentProtocolVersion)
+			{
+				message = $"Host protocol={packet.ProtocolVersion}, client protocol={ProtocolCompatibility.CurrentProtocolVersion}.";
+				return false;
+			}
+
+			if (packet.PacketRegistryFingerprint != ProtocolCompatibility.PacketFingerprint)
+			{
+				message = $"Host packet fingerprint={packet.PacketRegistryFingerprint}, client fingerprint={ProtocolCompatibility.PacketFingerprint}.";
+				return false;
+			}
+
+			return true;
 		}
 		static void BackToMainMenu()
 		{
@@ -413,4 +462,3 @@ namespace ONI_MP.Networking
 		}
 	}
 }
-

--- a/ClassLibrary1/Networking/MultiplayerPlayer.cs
+++ b/ClassLibrary1/Networking/MultiplayerPlayer.cs
@@ -13,12 +13,14 @@ public class MultiplayerPlayer
 	//public HSteamNetConnection? Connection { get; set; } = null;
 	public object? Connection { get; set; } = null;
 	public bool IsConnected => Connection != null;
+	public bool ProtocolVerified { get; set; }
 
 	public ClientReadyState readyState = ClientReadyState.Ready;
 
     public MultiplayerPlayer(ulong playerId)
 	{
 		PlayerId = playerId;
+		ProtocolVerified = IsLocal;
 		if(NetworkConfig.IsLanConfig())
 		{
             PlayerName = $"Player {playerId}";

--- a/ClassLibrary1/Networking/MultiplayerSession.cs
+++ b/ClassLibrary1/Networking/MultiplayerSession.cs
@@ -46,6 +46,7 @@ namespace ONI_MP.Networking
 			KnownPlayerNames.Clear();
 			HostUserID = Utils.NilUlong();
 			WorkProgressPatch.ClearTracking();
+			RemoteProgressRegistry.ClearAll();
 			DebugConsole.Log("[MultiplayerSession] Session cleared.");
 		}
 

--- a/ClassLibrary1/Networking/Packets/Animation/MultiToolSyncPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/MultiToolSyncPacket.cs
@@ -55,7 +55,7 @@ namespace ONI_MP.Networking.Packets.Animation
 				return;
 
 			if (!NetworkIdentityRegistry.TryGetComponent<StandardWorker>(WorkerNetId, out var worker)
-			|| !NetworkIdentityRegistry.TryGetComponent<Workable>(WorkerNetId, out var workable))
+			|| !NetworkIdentityRegistry.TryGetComponent<Workable>(WorkableNetId, out var workable))
 				return;
 
 			var hiteffect = Assets.TryGetPrefab(HitEffectPrefabId);

--- a/ClassLibrary1/Networking/Packets/Animation/StandardWorker_WorkingState_Packet.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/StandardWorker_WorkingState_Packet.cs
@@ -2,6 +2,7 @@
 using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.Architecture;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -66,47 +67,111 @@ namespace ONI_MP.Networking.Packets.Animation
 			if (MultiplayerSession.IsHost)
 				return;
 
-			if (!NetworkIdentityRegistry.TryGetComponent<StandardWorker>(WorkerNetId, out var worker))
+			if (TryApply())
 				return;
 
-			GameObject workableGO = null;
-			if (StartingToWork)
+			if (StartingToWork && Game.Instance != null)
 			{
-				if (!NetworkIdentityRegistry.TryGetComponent<Workable>(WorkableNetId, out var protoWorkable))
-					return;
+				Game.Instance.StartCoroutine(RetryStartWork(Clone()));
+			}
+		}
 
-				workableGO = protoWorkable.gameObject;
+		private bool TryApply(bool logFailure = false)
+		{
+			using var _ = Profiler.Scope();
 
-				var workableType = AccessTools.TypeByName(WorkableType);
-				if(workableType == null)
+			if (!NetworkIdentityRegistry.TryGetComponent<StandardWorker>(WorkerNetId, out var worker))
+			{
+				if (logFailure)
+				{
+					DebugConsole.LogWarning($"[StandardWorker_WorkingState_Packet] Could not find worker {WorkerNetId}");
+				}
+				return false;
+			}
+
+			GameObject workableGO = null;
+			if (!StartingToWork)
+			{
+				worker.StopWork();
+				DebugConsole.Log("[StandardWorker_WorkingState_Packet] workable change triggered for " + worker.name + ": stopped working");
+				return true;
+			}
+
+			if (!NetworkIdentityRegistry.TryGetComponent<Workable>(WorkableNetId, out var protoWorkable))
+			{
+				if (logFailure)
+				{
+					DebugConsole.LogWarning($"[StandardWorker_WorkingState_Packet] Could not resolve workable {WorkableNetId} for worker {worker.name}");
+				}
+				return false;
+			}
+
+			workableGO = protoWorkable.gameObject;
+
+			var workableType = AccessTools.TypeByName(WorkableType);
+			if (workableType == null)
+			{
+				if (logFailure)
 				{
 					DebugConsole.LogWarning("Could not find workable type " + WorkableType);
 				}
+				return false;
+			}
 
-				var targetWorkableCmp = workableGO.GetComponent(workableType);
-				if (targetWorkableCmp == null || targetWorkableCmp is not Workable workable)
+			var targetWorkableCmp = workableGO.GetComponent(workableType);
+			if (targetWorkableCmp == null || targetWorkableCmp is not Workable workable)
+			{
+				if (logFailure)
 				{
 					DebugConsole.LogWarning("Could not find workable of type " + WorkableType + " on " + workableGO.GetProperName());
-					return;
 				}
+				return false;
+			}
 
-				try
+			try
+			{
+				if (!worker.state.Equals(StandardWorker.State.Idle))
 				{
-					if (!worker.state.Equals(StandardWorker.State.Idle))
-					{
-						worker.StopWork();
-					}
-					worker.StartWork(new(workable));
+					worker.StopWork();
 				}
-				catch (System.Exception ex)
+				worker.StartWork(new(workable));
+			}
+			catch (System.Exception ex)
+			{
+				if (logFailure)
 				{
 					DebugConsole.LogWarning($"[StandardWorker_WorkingState_Packet] StartWork failed for {worker.name} on {workableGO.name}: {ex.GetType().Name}");
 				}
-            }
-			else
-				worker.StopWork();
+				return false;
+			}
 
-			DebugConsole.Log("[StandardWorker_WorkingState_Packet] workable change triggered for " + worker.name + ": " + (StartingToWork ? "Started working on " + workableGO.name : "stopped working"));
+			DebugConsole.Log("[StandardWorker_WorkingState_Packet] workable change triggered for " + worker.name + ": Started working on " + workableGO.name);
+			return true;
+		}
+
+		private StandardWorker_WorkingState_Packet Clone()
+		{
+			return new StandardWorker_WorkingState_Packet
+			{
+				WorkerNetId = WorkerNetId,
+				WorkableNetId = WorkableNetId,
+				WorkableType = WorkableType,
+				StartingToWork = StartingToWork
+			};
+		}
+
+		private static IEnumerator RetryStartWork(StandardWorker_WorkingState_Packet packet)
+		{
+			for (int attempt = 0; attempt < 10; attempt++)
+			{
+				yield return null;
+
+				if (!MultiplayerSession.InSession || MultiplayerSession.IsHost)
+					yield break;
+
+				if (packet.TryApply(logFailure: attempt == 9))
+					yield break;
+			}
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketRegistry.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketRegistry.cs
@@ -109,6 +109,23 @@ namespace ONI_MP.Networking.Packets.Architecture
 			DebugConsole.LogSuccess($"[PacketRegistry] Auto-registering {count} packets took {duration.TotalMilliseconds} ms");
 		}
 
+		public static int GetRegisteredPacketFingerprint()
+		{
+			using var _ = Profiler.Scope();
+
+			int[] ids = _PacketTypes.Keys.OrderBy(id => id).ToArray();
+			using var ms = new MemoryStream();
+			using var writer = new BinaryWriter(ms);
+			foreach (int id in ids)
+			{
+				writer.Write(id);
+			}
+
+			using var sha256 = SHA256.Create();
+			byte[] hash = sha256.ComputeHash(ms.ToArray());
+			return BitConverter.ToInt32(hash, 0);
+		}
+
         public static void TryRegister(Type packetType, string nameOverride = "")
         {
 	        using var _ = Profiler.Scope();

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -199,6 +199,23 @@ namespace ONI_MP.Networking
 			return SendToConnection(player.Connection, packet, sendType);
 		}
 
+		private static bool CanBroadcastTo(MultiplayerPlayer player)
+		{
+			using var _ = Profiler.Scope();
+
+			if (player == null || player.Connection == null)
+			{
+				return false;
+			}
+
+			if (!MultiplayerSession.IsHost || player.PlayerId == MultiplayerSession.HostUserID)
+			{
+				return true;
+			}
+
+			return player.ProtocolVerified;
+		}
+
 		public static void SendToHost(IPacket packet, PacketSendMode sendType = PacketSendMode.ReliableImmediate)
 		{
 			using var _ = Profiler.Scope();
@@ -221,7 +238,7 @@ namespace ONI_MP.Networking
 				if (exclude.HasValue && player.PlayerId == exclude.Value)
 					continue;
 
-				if (player.Connection != null)
+				if (CanBroadcastTo(player))
 					SendToConnection(player.Connection, packet, sendType);
 			}
 		}
@@ -247,7 +264,7 @@ namespace ONI_MP.Networking
 				if (excludedIds != null && excludedIds.Contains(player.PlayerId))
 					continue;
 
-				if (player.Connection != null)
+				if (CanBroadcastTo(player))
 					SendToConnection(player.Connection, packet, sendType);
 			}
 		}

--- a/ClassLibrary1/Networking/Packets/Handshake/GameStateRequestPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Handshake/GameStateRequestPacket.cs
@@ -1,25 +1,41 @@
-﻿using ONI_MP.Networking.Packets.Architecture;
-using ONI_MP.Networking.States;
-using Steamworks;
-using System;
+﻿using ONI_MP.DebugTools;
+using ONI_MP.Networking.Packets.Architecture;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Shared.Profiling;
+using UnityEngine;
 
 namespace ONI_MP.Networking.Packets.Handshake
 {
 	public class GameStateRequestPacket : IPacket
 	{
 		public GameStateRequestPacket() { }
-		public GameStateRequestPacket(ulong steamID) { ClientId = steamID; }
+		public GameStateRequestPacket(ulong steamID)
+		{
+			ClientId = steamID;
+		}
 
 		public ulong ClientId;
 		public HashSet<string> ActiveDlcIds = [];
 		public List<ulong> ActiveModIds = [];
+		public int ProtocolVersion;
+		public int PacketRegistryFingerprint;
+		public string ModVersion = string.Empty;
+		public bool ProtocolAccepted = true;
+		public string ProtocolFailureReason = string.Empty;
 
+		public bool HasProtocolMetadata { get; private set; }
+
+		public static GameStateRequestPacket CreateClientRequest(ulong clientId)
+		{
+			using var _ = Profiler.Scope();
+
+			var packet = new GameStateRequestPacket(clientId);
+			packet.PopulateProtocolMetadata();
+			return packet;
+		}
 
 		public void Serialize(BinaryWriter writer)
 		{
@@ -36,6 +52,12 @@ namespace ONI_MP.Networking.Packets.Handshake
 			{
 				writer.Write(id);
 			}
+
+			writer.Write(ProtocolVersion);
+			writer.Write(PacketRegistryFingerprint);
+			writer.Write(ModVersion ?? string.Empty);
+			writer.Write(ProtocolAccepted);
+			writer.Write(ProtocolFailureReason ?? string.Empty);
 		}
 
 		public void Deserialize(BinaryReader reader)
@@ -56,6 +78,21 @@ namespace ONI_MP.Networking.Packets.Handshake
 			{
 				ActiveModIds.Add(reader.ReadUInt64());
 			}
+
+			HasProtocolMetadata = false;
+			ProtocolAccepted = true;
+			ProtocolFailureReason = string.Empty;
+			if (reader.BaseStream.Position >= reader.BaseStream.Length)
+			{
+				return;
+			}
+
+			ProtocolVersion = reader.ReadInt32();
+			PacketRegistryFingerprint = reader.ReadInt32();
+			ModVersion = reader.ReadString();
+			ProtocolAccepted = reader.ReadBoolean();
+			ProtocolFailureReason = reader.ReadString();
+			HasProtocolMetadata = true;
 		}
 
 		public void OnDispatched()
@@ -67,7 +104,7 @@ namespace ONI_MP.Networking.Packets.Handshake
 
 			if (MultiplayerSession.IsHost)
 			{
-				CreateStateResponse();
+				HandleHostRequest();
 			}
 			else
 			{
@@ -75,17 +112,42 @@ namespace ONI_MP.Networking.Packets.Handshake
 			}
 		}
 
-		void CreateStateResponse()
+		private void HandleHostRequest()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!IsProtocolCompatible(out string reason))
+			{
+				DebugConsole.LogWarning($"[GameStateRequestPacket] Rejecting client {ClientId}: {reason}");
+				RejectClient(reason);
+				return;
+			}
+
+			MarkClientAsProtocolVerified();
+			CreateStateResponse();
+		}
+
+		private void CreateStateResponse()
 		{
 			using var _ = Profiler.Scope();
 
 			PacketSender.SendToPlayer(ClientId, AccumulateStateInfo());
 		}
-		static GameStateRequestPacket AccumulateStateInfo()
+
+		private static GameStateRequestPacket AccumulateStateInfo(bool protocolAccepted = true, string protocolFailureReason = "")
 		{
 			using var _ = Profiler.Scope();
 
 			var packet = new GameStateRequestPacket();
+			packet.PopulateProtocolMetadata();
+			packet.ProtocolAccepted = protocolAccepted;
+			packet.ProtocolFailureReason = protocolFailureReason ?? string.Empty;
+
+			if (!protocolAccepted)
+			{
+				return packet;
+			}
+
 			packet.ActiveDlcIds = SaveLoader.Instance.GameInfo.dlcIds.ToHashSet();
 			packet.ActiveModIds.Clear();
 
@@ -100,11 +162,86 @@ namespace ONI_MP.Networking.Packets.Handshake
 			return packet;
 		}
 
-		void ConsumeStateResponse()
+		private void ConsumeStateResponse()
 		{
 			using var _ = Profiler.Scope();
 
 			GameClient.OnHostResponseReceived(this);
+		}
+
+		private void PopulateProtocolMetadata()
+		{
+			using var _ = Profiler.Scope();
+
+			ProtocolVersion = ProtocolCompatibility.CurrentProtocolVersion;
+			PacketRegistryFingerprint = ProtocolCompatibility.PacketFingerprint;
+			ModVersion = ProtocolCompatibility.ModVersion;
+			HasProtocolMetadata = true;
+		}
+
+		private bool IsProtocolCompatible(out string reason)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!HasProtocolMetadata)
+			{
+				reason = ProtocolCompatibility.BuildMismatchReason(ProtocolVersion, PacketRegistryFingerprint, ModVersion, false);
+				return false;
+			}
+
+			if (!ProtocolCompatibility.Matches(ProtocolVersion, PacketRegistryFingerprint))
+			{
+				reason = ProtocolCompatibility.BuildMismatchReason(ProtocolVersion, PacketRegistryFingerprint, ModVersion, true);
+				return false;
+			}
+
+			reason = string.Empty;
+			return true;
+		}
+
+		private void MarkClientAsProtocolVerified()
+		{
+			using var _ = Profiler.Scope();
+
+			var player = MultiplayerSession.GetPlayer(ClientId);
+			if (player != null)
+			{
+				player.ProtocolVerified = true;
+			}
+		}
+
+		private void RejectClient(string reason)
+		{
+			using var _ = Profiler.Scope();
+
+			var player = MultiplayerSession.GetPlayer(ClientId);
+			if (player != null)
+			{
+				player.ProtocolVerified = false;
+			}
+
+			if (HasProtocolMetadata)
+			{
+				PacketSender.SendToPlayer(ClientId, AccumulateStateInfo(protocolAccepted: false, protocolFailureReason: reason), PacketSendMode.ReliableImmediate);
+			}
+
+			if (Game.Instance != null)
+			{
+				Game.Instance.StartCoroutine(DelayedKick(ClientId, HasProtocolMetadata ? 0.25f : 0f));
+				return;
+			}
+
+			NetworkConfig.TransportServer?.KickClient(ClientId);
+		}
+
+		private static IEnumerator DelayedKick(ulong clientId, float delay)
+		{
+			if (delay > 0f)
+			{
+				yield return new WaitForSecondsRealtime(delay);
+			}
+
+			NetworkConfig.TransportServer?.KickClient(clientId);
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Packets/World/Buildings/ComplexFabricatorSpawnProductPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/Buildings/ComplexFabricatorSpawnProductPacket.cs
@@ -51,6 +51,7 @@ namespace ONI_MP.Networking.Packets.World.Buildings
 			ComplexRecipe complexRecipe = fab.recipe_list[CompletedRecipeIdx];
 			DebugConsole.Log($"[ComplexFabricatorSpawnProductPacket] spawning product {complexRecipe.id} for {fab.name} with netId {NetId}");
 			fab.SpawnOrderProduct(complexRecipe);
+			RemoteProgressRegistry.Clear(NetId, RemoteProgressKind.ComplexFabricatorOrder);
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Packets/World/Handlers/BuildingConfigHandlerRegistry.cs
+++ b/ClassLibrary1/Networking/Packets/World/Handlers/BuildingConfigHandlerRegistry.cs
@@ -45,6 +45,7 @@ namespace ONI_MP.Networking.Packets.World.Handlers
 			RegisterHandler(new CraftingHandler());
 			RegisterHandler(new CometDetectorHandler());
 			RegisterHandler(new ToggleableHandler());
+			RegisterHandler(new UprootHandler());
 
 			DebugConsole.Log($"[BuildingConfigHandlerRegistry] Initialized with {_allHandlers.Count} handlers, {_handlersByHash.Count} hash mappings");
 		}

--- a/ClassLibrary1/Networking/Packets/World/Handlers/UprootHandler.cs
+++ b/ClassLibrary1/Networking/Packets/World/Handlers/UprootHandler.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using ONI_MP.DebugTools;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking.Packets.World.Handlers
+{
+	public class UprootHandler : IBuildingConfigHandler
+	{
+		private static readonly int[] _hashes = new int[]
+		{
+			"UprootPlant".GetHashCode(),
+		};
+
+		public int[] SupportedConfigHashes => _hashes;
+
+		public bool TryApplyConfig(GameObject go, BuildingConfigPacket packet)
+		{
+			using var _ = Profiler.Scope();
+
+			int hash = packet.ConfigHash;
+
+			// The packet uses Cell to find the plant since plants don't have NetworkIdentity on the building
+			// We need to find the Uprootable at the cell
+			if (!Grid.IsValidCell(packet.Cell)) return false;
+
+			// Find the plant at the cell - check the go first, then search grid objects
+			Uprootable uprootable = go.GetComponent<Uprootable>();
+
+			if (uprootable == null)
+			{
+				// Search for the plant entity at this cell
+				// Plants can be on different object layers
+				for (int layer = 0; layer < (int)ObjectLayer.NumLayers; layer++)
+				{
+					var obj = Grid.Objects[packet.Cell, layer];
+					if (obj != null)
+					{
+						uprootable = obj.GetComponent<Uprootable>();
+						if (uprootable != null) break;
+					}
+				}
+			}
+
+			if (uprootable == null) return false;
+
+			if (hash == "UprootPlant".GetHashCode())
+			{
+				uprootable.MarkForUproot();
+				DebugConsole.Log($"[UprootHandler] Marked plant for uproot at cell {packet.Cell}");
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/World/PlantGrowthStatePacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/PlantGrowthStatePacket.cs
@@ -1,0 +1,75 @@
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Architecture;
+using System.Collections.Generic;
+using System.IO;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking.Packets.World
+{
+	public struct PlantData
+	{
+		public int PlantNetId;
+		public int ReceptacleNetId;
+		public int Cell;
+		public string PlantPrefabTag;
+		public float Maturity;
+		public bool IsWilting;
+		public bool IsHarvestReady;
+		public bool IsWild;
+	}
+
+	public class PlantGrowthStatePacket : IPacket
+	{
+		public List<PlantData> Plants = new List<PlantData>();
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write(Plants.Count);
+			foreach (var p in Plants)
+			{
+				writer.Write(p.PlantNetId);
+				writer.Write(p.ReceptacleNetId);
+				writer.Write(p.Cell);
+				writer.Write(p.PlantPrefabTag ?? string.Empty);
+				writer.Write(p.Maturity);
+				writer.Write(p.IsWilting);
+				writer.Write(p.IsHarvestReady);
+				writer.Write(p.IsWild);
+			}
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			int count = reader.ReadInt32();
+			Plants = new List<PlantData>(count);
+
+			for (int i = 0; i < count; i++)
+			{
+				Plants.Add(new PlantData
+				{
+					PlantNetId = reader.ReadInt32(),
+					ReceptacleNetId = reader.ReadInt32(),
+					Cell = reader.ReadInt32(),
+					PlantPrefabTag = reader.ReadString(),
+					Maturity = reader.ReadSingle(),
+					IsWilting = reader.ReadBoolean(),
+					IsHarvestReady = reader.ReadBoolean(),
+					IsWild = reader.ReadBoolean()
+				});
+			}
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost) return;
+
+			PlantGrowthSyncer.Instance?.OnPlantStateReceived(this);
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/World/PlantLifecyclePacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/PlantLifecyclePacket.cs
@@ -1,0 +1,96 @@
+using ONI_MP.DebugTools;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Profiling;
+using System.Collections;
+using System.IO;
+using UnityEngine;
+
+namespace ONI_MP.Networking.Packets.World
+{
+	public enum PlantLifecycleOperation : byte
+	{
+		Spawn = 0,
+		Remove = 1,
+	}
+
+	public class PlantLifecyclePacket : IPacket
+	{
+		public PlantLifecycleOperation Operation;
+		public PlantData Plant;
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write((byte)Operation);
+			writer.Write(Plant.PlantNetId);
+			writer.Write(Plant.ReceptacleNetId);
+			writer.Write(Plant.Cell);
+			writer.Write(Plant.PlantPrefabTag ?? string.Empty);
+			writer.Write(Plant.Maturity);
+			writer.Write(Plant.IsWilting);
+			writer.Write(Plant.IsHarvestReady);
+			writer.Write(Plant.IsWild);
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			Operation = (PlantLifecycleOperation)reader.ReadByte();
+			Plant = new PlantData
+			{
+				PlantNetId = reader.ReadInt32(),
+				ReceptacleNetId = reader.ReadInt32(),
+				Cell = reader.ReadInt32(),
+				PlantPrefabTag = reader.ReadString(),
+				Maturity = reader.ReadSingle(),
+				IsWilting = reader.ReadBoolean(),
+				IsHarvestReady = reader.ReadBoolean(),
+				IsWild = reader.ReadBoolean()
+			};
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost)
+				return;
+
+			if (PlantGrowthSyncer.Instance?.OnPlantLifecycleReceived(this) == true)
+				return;
+
+			if (Game.Instance != null)
+			{
+				Game.Instance.StartCoroutine(RetryApply(Clone()));
+			}
+		}
+
+		private PlantLifecyclePacket Clone()
+		{
+			return new PlantLifecyclePacket
+			{
+				Operation = Operation,
+				Plant = Plant
+			};
+		}
+
+		private static IEnumerator RetryApply(PlantLifecyclePacket packet)
+		{
+			for (int attempt = 0; attempt < 10; attempt++)
+			{
+				yield return null;
+
+				if (!MultiplayerSession.InSession || MultiplayerSession.IsHost)
+					yield break;
+
+				if (PlantGrowthSyncer.Instance?.OnPlantLifecycleReceived(packet) == true)
+					yield break;
+			}
+
+			DebugConsole.LogWarning($"[PlantLifecyclePacket] Failed to apply {packet.Operation} for plant {packet.Plant.PlantPrefabTag} at cell {packet.Plant.Cell}");
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/World/WorkableProgressPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/WorkableProgressPacket.cs
@@ -1,0 +1,219 @@
+using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Profiling;
+using System.Collections;
+using System.IO;
+using UnityEngine;
+
+namespace ONI_MP.Networking.Packets.World
+{
+	internal class WorkableProgressPacket : IPacket
+	{
+		private int TargetNetId;
+		private string TargetTypeName;
+		private RemoteProgressKind ProgressKind;
+		private float PercentComplete;
+		private bool ShowProgressBar;
+		private float WorkTimeRemaining;
+		private float WorkTimeTotal;
+
+		public WorkableProgressPacket() { }
+
+		public WorkableProgressPacket(Workable workable)
+		{
+			using var _ = Profiler.Scope();
+
+			PopulateFromWorkable(workable, showProgressBar: true);
+		}
+
+		public static WorkableProgressPacket CreateHidden(Workable workable)
+		{
+			using var _ = Profiler.Scope();
+
+			var packet = new WorkableProgressPacket();
+			packet.PopulateFromWorkable(workable, showProgressBar: false);
+			return packet;
+		}
+
+		public static WorkableProgressPacket CreateComplexFabricator(ComplexFabricator fabricator, bool showProgressBar)
+		{
+			using var _ = Profiler.Scope();
+
+			var packet = new WorkableProgressPacket
+			{
+				TargetNetId = fabricator.GetNetId(),
+				TargetTypeName = fabricator.GetType().AssemblyQualifiedName,
+				ProgressKind = RemoteProgressKind.ComplexFabricatorOrder,
+				PercentComplete = Mathf.Clamp01(fabricator.OrderProgress),
+				ShowProgressBar = showProgressBar,
+				WorkTimeRemaining = showProgressBar ? 1f - Mathf.Clamp01(fabricator.OrderProgress) : 0f,
+				WorkTimeTotal = 1f
+			};
+			return packet;
+		}
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write(TargetNetId);
+			writer.Write(TargetTypeName ?? string.Empty);
+			writer.Write((int)ProgressKind);
+			writer.Write(PercentComplete);
+			writer.Write(ShowProgressBar);
+			writer.Write(WorkTimeRemaining);
+			writer.Write(WorkTimeTotal);
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			TargetNetId = reader.ReadInt32();
+			TargetTypeName = reader.ReadString();
+			ProgressKind = (RemoteProgressKind)reader.ReadInt32();
+			PercentComplete = reader.ReadSingle();
+			ShowProgressBar = reader.ReadBoolean();
+			WorkTimeRemaining = reader.ReadSingle();
+			WorkTimeTotal = reader.ReadSingle();
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost)
+				return;
+
+			if (TryApply())
+				return;
+
+			if (Game.Instance != null)
+			{
+				Game.Instance.StartCoroutine(RetryApply(Clone()));
+			}
+		}
+
+		private void PopulateFromWorkable(Workable workable, bool showProgressBar)
+		{
+			using var _ = Profiler.Scope();
+
+			TargetNetId = workable.GetNetId();
+			TargetTypeName = workable.GetType().AssemblyQualifiedName;
+			ProgressKind = RemoteProgressKind.WorkablePercent;
+			PercentComplete = Mathf.Clamp01(workable.GetPercentComplete());
+			ShowProgressBar = showProgressBar;
+			WorkTimeRemaining = showProgressBar ? workable.WorkTimeRemaining : 0f;
+			WorkTimeTotal = workable.GetWorkTime();
+		}
+
+		private WorkableProgressPacket Clone()
+		{
+			return new WorkableProgressPacket
+			{
+				TargetNetId = TargetNetId,
+				TargetTypeName = TargetTypeName,
+				ProgressKind = ProgressKind,
+				PercentComplete = PercentComplete,
+				ShowProgressBar = ShowProgressBar,
+				WorkTimeRemaining = WorkTimeRemaining,
+				WorkTimeTotal = WorkTimeTotal
+			};
+		}
+
+		private bool TryApply()
+		{
+			using var _ = Profiler.Scope();
+
+			switch (ProgressKind)
+			{
+				case RemoteProgressKind.WorkablePercent:
+					return TryApplyWorkableProgress();
+
+				case RemoteProgressKind.ComplexFabricatorOrder:
+					return TryApplyComplexFabricatorProgress();
+
+				default:
+					return true;
+			}
+		}
+
+		private bool TryApplyWorkableProgress()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!NetworkIdentityRegistry.TryGet(TargetNetId, out var identity) || identity == null || identity.gameObject.IsNullOrDestroyed())
+				return false;
+
+			Workable workable = null;
+			if (!string.IsNullOrEmpty(TargetTypeName))
+			{
+				var workableType = AccessTools.TypeByName(TargetTypeName);
+				if (workableType == null)
+					return false;
+
+				workable = identity.gameObject.GetComponent(workableType) as Workable;
+			}
+
+			workable ??= identity.gameObject.GetComponent<Workable>();
+			if (workable == null)
+				return false;
+
+			if (WorkTimeTotal > 0f && !float.IsInfinity(WorkTimeTotal) && !float.IsNaN(WorkTimeTotal))
+			{
+				workable.SetWorkTime(WorkTimeTotal);
+				workable.WorkTimeRemaining = Mathf.Clamp(WorkTimeRemaining, 0f, WorkTimeTotal);
+			}
+
+			workable.ShowProgressBar(ShowProgressBar);
+			if (ShowProgressBar)
+			{
+				RemoteProgressRegistry.SetProgress(TargetNetId, ProgressKind, PercentComplete, true, WorkTimeRemaining, WorkTimeTotal);
+			}
+			else
+			{
+				RemoteProgressRegistry.Clear(TargetNetId, ProgressKind, hideTarget: false);
+			}
+
+			return true;
+		}
+
+		private bool TryApplyComplexFabricatorProgress()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!NetworkIdentityRegistry.TryGetComponent<ComplexFabricator>(TargetNetId, out var fabricator) || fabricator == null || fabricator.gameObject.IsNullOrDestroyed())
+				return false;
+
+			fabricator.OrderProgress = Mathf.Clamp01(PercentComplete);
+			fabricator.ShowProgressBar(ShowProgressBar);
+			if (ShowProgressBar)
+			{
+				RemoteProgressRegistry.SetProgress(TargetNetId, ProgressKind, PercentComplete, true, WorkTimeRemaining, WorkTimeTotal);
+			}
+			else
+			{
+				RemoteProgressRegistry.Clear(TargetNetId, ProgressKind, hideTarget: false);
+			}
+
+			return true;
+		}
+
+		private static IEnumerator RetryApply(WorkableProgressPacket packet)
+		{
+			for (int attempt = 0; attempt < 12; attempt++)
+			{
+				yield return null;
+
+				if (!MultiplayerSession.InSession || MultiplayerSession.IsHost)
+					yield break;
+
+				if (packet.TryApply())
+					yield break;
+			}
+
+			DebugConsole.LogWarning($"[WorkableProgressPacket] Failed to resolve target {packet.TargetNetId} ({packet.TargetTypeName})");
+		}
+	}
+}

--- a/ClassLibrary1/Networking/ProtocolCompatibility.cs
+++ b/ClassLibrary1/Networking/ProtocolCompatibility.cs
@@ -1,0 +1,68 @@
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking
+{
+	internal static class ProtocolCompatibility
+	{
+		public const int CurrentProtocolVersion = 1;
+
+		private static int? _packetFingerprint;
+		private static string _modVersion;
+
+		public static int PacketFingerprint
+		{
+			get
+			{
+				using var _ = Profiler.Scope();
+
+				return _packetFingerprint ??= PacketRegistry.GetRegisteredPacketFingerprint();
+			}
+		}
+
+		public static string ModVersion
+		{
+			get
+			{
+				using var _ = Profiler.Scope();
+
+				return _modVersion ??= ONI_MP.ModUpdater.Updater.GetVersion();
+			}
+		}
+
+		public static bool Matches(int protocolVersion, int packetFingerprint)
+		{
+			using var _ = Profiler.Scope();
+
+			return protocolVersion == CurrentProtocolVersion
+				&& packetFingerprint == PacketFingerprint;
+		}
+
+		public static string BuildMismatchReason(int remoteProtocolVersion, int remotePacketFingerprint, string remoteModVersion, bool hasMetadata)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!hasMetadata)
+			{
+				return "Peer is running a build without protocol metadata.";
+			}
+
+			if (remoteProtocolVersion != CurrentProtocolVersion)
+			{
+				return $"Protocol mismatch. Host={CurrentProtocolVersion}, Peer={remoteProtocolVersion}.";
+			}
+
+			if (remotePacketFingerprint != PacketFingerprint)
+			{
+				return $"Packet registry mismatch. Host={PacketFingerprint}, Peer={remotePacketFingerprint}.";
+			}
+
+			if (!string.IsNullOrEmpty(remoteModVersion) && remoteModVersion != ModVersion)
+			{
+				return $"Mod version mismatch. Host={ModVersion}, Peer={remoteModVersion}.";
+			}
+
+			return "Peer is running an incompatible build.";
+		}
+	}
+}

--- a/ClassLibrary1/Networking/RemoteProgressRegistry.cs
+++ b/ClassLibrary1/Networking/RemoteProgressRegistry.cs
@@ -1,0 +1,167 @@
+using Shared.Profiling;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ONI_MP.Networking
+{
+	internal enum RemoteProgressKind
+	{
+		WorkablePercent = 0,
+		ComplexFabricatorOrder = 1
+	}
+
+	internal struct RemoteProgressState
+	{
+		public float PercentComplete;
+		public bool ShowProgressBar;
+		public float WorkTimeRemaining;
+		public float WorkTimeTotal;
+		public float ExpireAt;
+	}
+
+	internal static class RemoteProgressRegistry
+	{
+		private struct RemoteProgressKey
+		{
+			public int NetId;
+			public RemoteProgressKind Kind;
+
+			public override int GetHashCode()
+			{
+				return unchecked((NetId * 397) ^ (int)Kind);
+			}
+		}
+
+		private const float ENTRY_TTL = 1.5f;
+		private static readonly Dictionary<RemoteProgressKey, RemoteProgressState> _states = new();
+
+		public static void SetProgress(int netId, RemoteProgressKind kind, float percentComplete, bool showProgressBar, float workTimeRemaining, float workTimeTotal)
+		{
+			using var _ = Profiler.Scope();
+
+			var key = new RemoteProgressKey
+			{
+				NetId = netId,
+				Kind = kind
+			};
+
+			_states[key] = new RemoteProgressState
+			{
+				PercentComplete = Mathf.Clamp01(percentComplete),
+				ShowProgressBar = showProgressBar,
+				WorkTimeRemaining = workTimeRemaining,
+				WorkTimeTotal = workTimeTotal,
+				ExpireAt = Time.unscaledTime + ENTRY_TTL
+			};
+		}
+
+		public static bool TryGetState(int netId, RemoteProgressKind kind, out RemoteProgressState state)
+		{
+			using var _ = Profiler.Scope();
+
+			var key = new RemoteProgressKey
+			{
+				NetId = netId,
+				Kind = kind
+			};
+
+			if (!_states.TryGetValue(key, out state))
+			{
+				return false;
+			}
+
+			if (Time.unscaledTime <= state.ExpireAt)
+			{
+				return true;
+			}
+
+			_states.Remove(key);
+			HideTarget(netId, kind);
+			state = default;
+			return false;
+		}
+
+		public static bool TryGetPercent(int netId, RemoteProgressKind kind, out float percentComplete)
+		{
+			using var _ = Profiler.Scope();
+
+			if (TryGetState(netId, kind, out var state))
+			{
+				percentComplete = state.PercentComplete;
+				return true;
+			}
+
+			percentComplete = 0f;
+			return false;
+		}
+
+		public static void Clear(int netId, RemoteProgressKind? kind = null, bool hideTarget = true)
+		{
+			using var _ = Profiler.Scope();
+
+			if (kind.HasValue)
+			{
+				ClearEntry(netId, kind.Value, hideTarget);
+				return;
+			}
+
+			ClearEntry(netId, RemoteProgressKind.WorkablePercent, hideTarget);
+			ClearEntry(netId, RemoteProgressKind.ComplexFabricatorOrder, hideTarget);
+		}
+
+		public static void ClearAll()
+		{
+			using var _ = Profiler.Scope();
+
+			_states.Clear();
+		}
+
+		private static void ClearEntry(int netId, RemoteProgressKind kind, bool hideTarget)
+		{
+			using var _ = Profiler.Scope();
+
+			var key = new RemoteProgressKey
+			{
+				NetId = netId,
+				Kind = kind
+			};
+
+			if (!_states.Remove(key))
+			{
+				return;
+			}
+
+			if (hideTarget)
+			{
+				HideTarget(netId, kind);
+			}
+		}
+
+		private static void HideTarget(int netId, RemoteProgressKind kind)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!NetworkIdentityRegistry.TryGet(netId, out var identity) || identity == null || identity.gameObject.IsNullOrDestroyed())
+			{
+				return;
+			}
+
+			switch (kind)
+			{
+				case RemoteProgressKind.WorkablePercent:
+					if (identity.TryGetComponent<Workable>(out var workable) && !workable.IsNullOrDestroyed())
+					{
+						workable.ShowProgressBar(false);
+					}
+					break;
+
+				case RemoteProgressKind.ComplexFabricatorOrder:
+					if (identity.TryGetComponent<ComplexFabricator>(out var fabricator) && !fabricator.IsNullOrDestroyed())
+					{
+						fabricator.ShowProgressBar(false);
+					}
+					break;
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Trackers/PlantTracker.cs
+++ b/ClassLibrary1/Networking/Trackers/PlantTracker.cs
@@ -1,0 +1,43 @@
+using HarmonyLib;
+using System.Collections.Generic;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking.Trackers
+{
+	public static class PlantTracker
+	{
+		public static readonly HashSet<Growing> AllPlants = new HashSet<Growing>();
+
+		[HarmonyPatch(typeof(Growing), nameof(Growing.OnSpawn))]
+		public static class Growing_OnSpawn_Patch
+		{
+			public static void Postfix(Growing __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				lock (AllPlants)
+				{
+					AllPlants.Add(__instance);
+				}
+			}
+		}
+
+		[HarmonyPatch(typeof(KPrefabID), nameof(KPrefabID.OnCleanUp))]
+		public static class KPrefabID_OnCleanUp_PlantTracker_Patch
+		{
+			public static void Prefix(KPrefabID __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				var growing = __instance.GetComponent<Growing>();
+				if (growing != null)
+				{
+					lock (AllPlants)
+					{
+						AllPlants.Remove(growing);
+					}
+				}
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Transport/Riptide/RiptideClient.cs
+++ b/ClassLibrary1/Networking/Transport/Riptide/RiptideClient.cs
@@ -122,15 +122,7 @@ namespace ONI_MP.Networking.Transport.Lan
             DebugConsole.Log($"[Riptide] Connected to server with Client ID: {CLIENT_ID}");
 
             //CoroutineRunner.RunOne(Handshake());
-
-            if (Utils.IsInGame())
-            {
-                NetworkConfig.TransportClient.OnContinueConnectionFlow.Invoke();
-            }
-            else
-            {
-                NetworkConfig.TransportClient.OnRequestStateOrReturn.Invoke();
-            }
+            NetworkConfig.TransportClient.OnRequestStateOrReturn.Invoke();
         }
 
         private void OnDisconnectedFromServer(object sender, DisconnectedEventArgs e)

--- a/ClassLibrary1/Networking/Transport/Steamworks/SteamworksClient.cs
+++ b/ClassLibrary1/Networking/Transport/Steamworks/SteamworksClient.cs
@@ -211,22 +211,14 @@ namespace ONI_MP.Networking.Transport.Steam
             DebugConsole.Log("[GameClient] Connection to host established!");
 
             // Skip mod verification if we are the host
-            if (MultiplayerSession.IsHost)
-            {
-                return;
-            }
+			if (MultiplayerSession.IsHost)
+			{
+				return;
+			}
 
-            PacketHandler.readyToProcess = true;
-
-            if (Utils.IsInGame())
-            {
-                NetworkConfig.TransportClient.OnContinueConnectionFlow.Invoke();
-            }
-            else
-            {
-                NetworkConfig.TransportClient.OnRequestStateOrReturn.Invoke();
-            }
-        }
+			PacketHandler.readyToProcess = true;
+			NetworkConfig.TransportClient.OnRequestStateOrReturn.Invoke();
+		}
 
         private static void OnDisconnected(string reason, CSteamID remote, ESteamNetworkingConnectionState state)
         {

--- a/ClassLibrary1/Patches/DuplicantActions/StandardWorker_Patches.cs
+++ b/ClassLibrary1/Patches/DuplicantActions/StandardWorker_Patches.cs
@@ -3,6 +3,7 @@ using ONI_MP.DebugTools;
 using ONI_MP.Misc;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Packets.Animation;
+using ONI_MP.Networking.Packets.World;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,8 +26,7 @@ namespace ONI_MP.Patches.DuplicantActions
 			{
                 typeof(DefragmentationZone),
                 typeof(RancherWorkable),
-                typeof(LiquidPumpingStation),
-				typeof(GunkEmptierWorkable)
+                typeof(LiquidPumpingStation)
             };
 
 			public static void Postfix(StandardWorker __instance, StartWorkInfo start_work_info)
@@ -55,6 +55,28 @@ namespace ONI_MP.Patches.DuplicantActions
 		[HarmonyPatch(typeof(StandardWorker), nameof(StandardWorker.StopWork))]
 		public class StandardWorker_StopWork_Patch
 		{
+			public static void Prefix(StandardWorker __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				if (__instance.IsNullOrDestroyed())
+					return;
+
+				if (!Utils.IsHostMinion(__instance))
+					return;
+
+				var workable = __instance.GetWorkable();
+				if (workable == null || workable.IsNullOrDestroyed())
+					return;
+
+				PacketSender.SendToAllClients(WorkableProgressPacket.CreateHidden(workable), PacketSendMode.ReliableImmediate);
+
+				if (workable.TryGetComponent<ComplexFabricator>(out var fabricator) && fabricator != null && !fabricator.IsNullOrDestroyed())
+				{
+					PacketSender.SendToAllClients(WorkableProgressPacket.CreateComplexFabricator(fabricator, showProgressBar: false), PacketSendMode.ReliableImmediate);
+				}
+			}
+
 			public static void Postfix(StandardWorker __instance)
 			{
 				using var _ = Profiler.Scope();

--- a/ClassLibrary1/Patches/WorkProgressPatch.cs
+++ b/ClassLibrary1/Patches/WorkProgressPatch.cs
@@ -21,24 +21,33 @@ public static class WorkProgressPatch
 		if (__instance.IsNullOrDestroyed())
 			return;
 
-		if (__instance is not Constructable && __instance is not Deconstructable)
+		if (ShouldSkip(__instance))
 			return;
 
 		float workTime = __instance.GetWorkTime();
-		if (workTime <= 0f || float.IsInfinity(workTime))
+		if (workTime <= 0f || float.IsInfinity(workTime) || float.IsNaN(workTime))
 			return;
 
-		if (__instance.GetPercentComplete() < 0f)
+		float percentComplete = __instance.GetPercentComplete();
+		if (float.IsNaN(percentComplete) || float.IsInfinity(percentComplete))
 			return;
 
-		int cell = Grid.PosToCell(__instance.transform.position);
+		int workableNetId = __instance.GetNetId();
+		if (workableNetId == 0)
+			return;
+
+		string workableType = __instance.GetType().AssemblyQualifiedName;
+		if (string.IsNullOrEmpty(workableType))
+			return;
+
+		int trackingKey = GetTrackingKey(workableNetId, workableType);
 		float now = Time.time;
 
-		if (nextSendTime.TryGetValue(cell, out float next) && now < next)
+		if (nextSendTime.TryGetValue(trackingKey, out float next) && now < next)
 			return;
 
-		nextSendTime[cell] = now + SEND_INTERVAL;
-		PacketSender.SendToAllClients(new WorkProgressPacket(cell, __instance.WorkTimeRemaining));
+		nextSendTime[trackingKey] = now + SEND_INTERVAL;
+		PacketSender.SendToAllClients(new WorkableProgressPacket(__instance), PacketSendMode.Unreliable);
 	}
 
 	public static void ClearTracking()
@@ -46,5 +55,17 @@ public static class WorkProgressPatch
 		using var _ = Profiler.Scope();
 
 		nextSendTime.Clear();
+	}
+
+	private static bool ShouldSkip(Workable workable)
+	{
+		return workable is DefragmentationZone
+			|| workable.GetType().Name == "RancherWorkable"
+			|| workable is LiquidPumpingStation;
+	}
+
+	private static int GetTrackingKey(int workableNetId, string workableType)
+	{
+		return unchecked((workableNetId * 397) ^ workableType.GetHashCode());
 	}
 }

--- a/ClassLibrary1/Patches/World/Buildings/ComplexFabricator_Patches.cs
+++ b/ClassLibrary1/Patches/World/Buildings/ComplexFabricator_Patches.cs
@@ -1,33 +1,71 @@
 ﻿using HarmonyLib;
-using ONI_MP.DebugTools;
 using ONI_MP.Networking;
+using ONI_MP.Networking.Packets.World;
 using ONI_MP.Networking.Packets.World.Buildings;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Shared.Profiling;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace ONI_MP.Patches.World.Buildings
 {
 	internal class ComplexFabricator_Patches
 	{
+		private const float SEND_INTERVAL = 0.5f;
+		private static readonly Dictionary<int, float> _nextSendTime = new();
 
-        [HarmonyPatch(typeof(ComplexFabricator), nameof(ComplexFabricator.SpawnOrderProduct))]
-        public class ComplexFabricator_SpawnOrderProduct_Patch
-        {
-            public static void Postfix(ComplexFabricator __instance)
+		[HarmonyPatch(typeof(ComplexFabricatorWorkable), nameof(ComplexFabricatorWorkable.UpdateOrderProgress))]
+		public class ComplexFabricatorWorkable_UpdateOrderProgress_Patch
+		{
+			public static void Postfix(ComplexFabricatorWorkable __instance)
 			{
 				using var _ = Profiler.Scope();
 
-				DebugConsole.Log("ComplexFabricator_SpawnOrderProduct_Patch called");
+				if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession || __instance.IsNullOrDestroyed())
+					return;
+
+				if (!__instance.TryGetComponent<ComplexFabricator>(out var fabricator) || fabricator == null || fabricator.IsNullOrDestroyed())
+					return;
+
+				int netId = fabricator.GetNetId();
+				if (netId == 0)
+					return;
+
+				float now = Time.time;
+				if (_nextSendTime.TryGetValue(netId, out float next) && now < next)
+					return;
+
+				_nextSendTime[netId] = now + SEND_INTERVAL;
+				PacketSender.SendToAllClients(WorkableProgressPacket.CreateComplexFabricator(fabricator, showProgressBar: true), PacketSendMode.Unreliable);
+			}
+		}
+
+		[HarmonyPatch(typeof(ComplexFabricator), nameof(ComplexFabricator.CancelWorkingOrder))]
+		public class ComplexFabricator_CancelWorkingOrder_Patch
+		{
+			public static void Postfix(ComplexFabricator __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession || __instance.IsNullOrDestroyed())
+					return;
+
+				PacketSender.SendToAllClients(WorkableProgressPacket.CreateComplexFabricator(__instance, showProgressBar: false), PacketSendMode.ReliableImmediate);
+			}
+		}
+
+		[HarmonyPatch(typeof(ComplexFabricator), nameof(ComplexFabricator.SpawnOrderProduct))]
+		public class ComplexFabricator_SpawnOrderProduct_Patch
+		{
+			public static void Postfix(ComplexFabricator __instance)
+			{
+				using var _ = Profiler.Scope();
+
 				if (!MultiplayerSession.InSession || !MultiplayerSession.IsHost)
 					return;
 
-				DebugConsole.Log("ComplexFabricator_SpawnOrderProduct_Patch spawning product");
+				PacketSender.SendToAllClients(WorkableProgressPacket.CreateComplexFabricator(__instance, showProgressBar: false), PacketSendMode.ReliableImmediate);
 				PacketSender.SendToAllClients(new ComplexFabricatorSpawnProductPacket(__instance));
 			}
-        }
+		}
 	}
 }

--- a/ClassLibrary1/Patches/World/Plants/PlantLifecyclePatches.cs
+++ b/ClassLibrary1/Patches/World/Plants/PlantLifecyclePatches.cs
@@ -1,0 +1,75 @@
+using HarmonyLib;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
+using Shared.Profiling;
+using UnityEngine;
+
+namespace ONI_MP.Patches.World.Plants
+{
+	[HarmonyPatch]
+	internal static class PlantLifecyclePatches
+	{
+		[HarmonyPatch(typeof(PlantablePlot), nameof(PlantablePlot.SpawnOccupyingObject))]
+		private static class PlantablePlot_SpawnOccupyingObject_Patch
+		{
+			private static void Postfix(PlantablePlot __instance, GameObject __result)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!MultiplayerSession.IsHostInSession)
+					return;
+				if (!PlantGrowthSyncer.CanBroadcastLifecycleEvents)
+					return;
+				if (__result == null || PlantGrowthSyncer.IsApplyingState)
+					return;
+				if (!__result.TryGetComponent<Growing>(out var growing) || growing == null)
+					return;
+
+				PlantGrowthSyncer.BroadcastPlantLifecycle(PlantLifecycleOperation.Spawn, growing, __instance);
+			}
+		}
+
+		[HarmonyPatch(typeof(Growing), nameof(Growing.OnSpawn))]
+		private static class Growing_OnSpawn_Patch
+		{
+			private static void Postfix(Growing __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!MultiplayerSession.IsHostInSession)
+					return;
+				if (!PlantGrowthSyncer.CanBroadcastLifecycleEvents)
+					return;
+				if (PlantGrowthSyncer.IsApplyingState || __instance == null)
+					return;
+				if (!__instance.IsWildPlanted())
+					return;
+
+				PlantGrowthSyncer.BroadcastPlantLifecycle(PlantLifecycleOperation.Spawn, __instance);
+			}
+		}
+
+		[HarmonyPatch(typeof(KPrefabID), nameof(KPrefabID.OnCleanUp))]
+		private static class KPrefabID_OnCleanUp_Patch
+		{
+			private static void Prefix(KPrefabID __instance)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!MultiplayerSession.IsHostInSession)
+					return;
+				if (!PlantGrowthSyncer.CanBroadcastLifecycleEvents)
+					return;
+				if (PlantGrowthSyncer.IsApplyingState || __instance == null)
+					return;
+
+				var growing = __instance.GetComponent<Growing>();
+				if (growing == null)
+					return;
+
+				PlantGrowthSyncer.BroadcastPlantLifecycle(PlantLifecycleOperation.Remove, growing);
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Patches/World/SideScreen/ReceptaclePatches.cs
+++ b/ClassLibrary1/Patches/World/SideScreen/ReceptaclePatches.cs
@@ -25,6 +25,13 @@ namespace ONI_MP.Patches.World.SideScreen
     [HarmonyPatch(typeof(SingleEntityReceptacle), nameof(SingleEntityReceptacle.CreateOrder))]
 	public static class SingleEntityReceptacle_CreateOrder_Patch
 	{
+		public static bool Prefix()
+		{
+			if (!MultiplayerSession.InSession) return true;
+			if (MultiplayerSession.IsHost) return true;
+			return false; // Client: skip CreateOrder to prevent preview plant; Postfix still sends packet
+		}
+
 		public static void Postfix(SingleEntityReceptacle __instance, Tag entityTag, Tag additionalFilterTag)
 		{
 			using var _ = Profiler.Scope();
@@ -73,6 +80,13 @@ namespace ONI_MP.Patches.World.SideScreen
 	[HarmonyPatch(typeof(SingleEntityReceptacle), nameof(SingleEntityReceptacle.CancelActiveRequest))]
 	public static class SingleEntityReceptacle_CancelActiveRequest_Patch
 	{
+		public static bool Prefix()
+		{
+			if (!MultiplayerSession.InSession) return true;
+			if (MultiplayerSession.IsHost) return true;
+			return false; // Client: skip, let host handle it
+		}
+
 		public static void Postfix(SingleEntityReceptacle __instance)
 		{
 			using var _ = Profiler.Scope();

--- a/ClassLibrary1/Patches/World/SideScreen/UprootPatches.cs
+++ b/ClassLibrary1/Patches/World/SideScreen/UprootPatches.cs
@@ -1,0 +1,35 @@
+using HarmonyLib;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.World.SideScreen
+{
+	[HarmonyPatch(typeof(Uprootable), nameof(Uprootable.MarkForUproot))]
+	public static class Uprootable_MarkForUproot_Patch
+	{
+		public static void Postfix(Uprootable __instance)
+		{
+			using var _ = Profiler.Scope();
+
+			if (BuildingConfigPacket.IsApplyingPacket) return;
+			if (!MultiplayerSession.InSession) return;
+			if (__instance.IsNullOrDestroyed()) return;
+
+			int cell = Grid.PosToCell(__instance.gameObject);
+
+			var packet = new BuildingConfigPacket
+			{
+				NetId = 0,
+				Cell = cell,
+				ConfigHash = "UprootPlant".GetHashCode(),
+				Value = 1f,
+				ConfigType = BuildingConfigType.Float
+			};
+
+			if (MultiplayerSession.IsHost) PacketSender.SendToAllClients(packet);
+			else PacketSender.SendToHost(packet);
+		}
+	}
+}

--- a/ClassLibrary1/Patches/World/WorkablePatch.cs
+++ b/ClassLibrary1/Patches/World/WorkablePatch.cs
@@ -1,16 +1,32 @@
 ﻿using HarmonyLib;
+using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Shared.Profiling;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
 
 namespace ONI_MP.Patches.World
 {
 	internal class WorkablePatch
 	{
+		private static bool TryGetRemotePercent(Component target, RemoteProgressKind progressKind, out float percentComplete)
+		{
+			using var _ = Profiler.Scope();
+
+			percentComplete = 0f;
+			if (!MultiplayerSession.IsClient || target == null || target.gameObject.IsNullOrDestroyed())
+			{
+				return false;
+			}
+
+			if (!target.gameObject.TryGetComponent<NetworkIdentity>(out var identity) || identity == null || identity.NetId == 0)
+			{
+				return false;
+			}
+
+			return RemoteProgressRegistry.TryGetPercent(identity.NetId, progressKind, out percentComplete);
+		}
 
 		[HarmonyPatch(typeof(Workable), nameof(Workable.OnPrefabInit))]
 		public class Workable_OnPrefabInit_Patch
@@ -19,8 +35,83 @@ namespace ONI_MP.Patches.World
 			{
 				using var _ = Profiler.Scope();
 
-				//if (__instance.multitoolContext.IsValid && __instance.multitoolHitEffectTag.IsValid)
 				__instance.gameObject.AddOrGet<NetworkIdentity>();
+			}
+		}
+
+		[HarmonyPatch(typeof(Workable), nameof(Workable.GetPercentComplete))]
+		public class Workable_GetPercentComplete_Patch
+		{
+			public static bool Prefix(Workable __instance, ref float __result)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!TryGetRemotePercent(__instance, RemoteProgressKind.WorkablePercent, out float percentComplete))
+				{
+					return true;
+				}
+
+				__result = percentComplete;
+				return false;
+			}
+		}
+
+		[HarmonyPatch]
+		public class DerivedWorkable_GetPercentComplete_Patch
+		{
+			private static IEnumerable<MethodBase> TargetMethods()
+			{
+				using var _ = Profiler.Scope();
+
+				string[] typeNames =
+				{
+					"Diggable",
+					"EmptyConduitWorkable",
+					"EmptySolidConduitWorkable",
+					"AstronautTrainingCenter",
+					"ResearchCenter",
+					"NuclearResearchCenterWorkable"
+				};
+
+				foreach (string typeName in typeNames)
+				{
+					var type = AccessTools.TypeByName(typeName);
+					var method = type == null ? null : AccessTools.Method(type, nameof(Workable.GetPercentComplete));
+					if (method != null)
+					{
+						yield return method;
+					}
+				}
+			}
+
+			public static bool Prefix(Component __instance, ref float __result)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!TryGetRemotePercent(__instance, RemoteProgressKind.WorkablePercent, out float percentComplete))
+				{
+					return true;
+				}
+
+				__result = percentComplete;
+				return false;
+			}
+		}
+
+		[HarmonyPatch(typeof(ComplexFabricator), "get_OrderProgress")]
+		public class ComplexFabricator_OrderProgress_Patch
+		{
+			public static bool Prefix(ComplexFabricator __instance, ref float __result)
+			{
+				using var _ = Profiler.Scope();
+
+				if (!TryGetRemotePercent(__instance, RemoteProgressKind.ComplexFabricatorOrder, out float percentComplete))
+				{
+					return true;
+				}
+
+				__result = percentComplete;
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
  - Add full plant growth synchronization between host and clients, supporting both real-time lifecycle events (plant/uproot) and periodic bulk state reconciliation every 5 seconds                                                                                                     
  - Introduce PlantTracker to track all active Growing components, PlantGrowthSyncer as the core sync engine, and dedicated packets (PlantGrowthStatePacket, PlantLifecyclePacket) for network transport                                                                                 
  - Patch plant lifecycle hooks (PlantLifecyclePatches, ReceptaclePatches, UprootPatches) and add UprootHandler for client-to-host uproot requests 

  - Extend work progress sync beyond construction/deconstruction to all workable types (research stations, digging, fabricators, etc.) using a new WorkableProgressPacket that targets entities by network ID instead of cell position                                                   
  - Add protocol version handshake during client connection — host and client now exchange protocol version, packet registry fingerprint, and mod version, rejecting mismatched peers with a descriptive error message                                                                   
  - Introduce RemoteProgressRegistry to track and expire remote progress state on clients, with Harmony patches on GetPercentComplete and ComplexFabricator.OrderProgress so progress bars render correctly without local simulation                                                     
  - Gate packet broadcasting behind ProtocolVerified flag to prevent sending game state to clients that haven't completed the handshake                                                                                                                                                  
  - Fix MultiToolSyncPacket using wrong net ID (was using WorkerNetId instead of WorkableNetId for the workable lookup) 