### PR TITLE
Introduce central anim sync coordinator

### DIFF
--- a/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
@@ -1,0 +1,122 @@
+using System.IO;
+using System.Linq;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Animation;
+
+namespace ONI_MP.DebugTools.UnitTests
+{
+	public static class AnimSyncTests
+	{
+		[UnitTest(name: "Anim reconciliation: detects wrong animation", category: "Animation")]
+		public static UnitTestResult DetectsWrongAnimation()
+		{
+			var identities = NetworkIdentityRegistry.AllIdentities;
+			foreach (var id in identities)
+			{
+				if (!id.gameObject.TryGetComponent<KBatchedAnimController>(out var kbac))
+					continue;
+				if (!id.gameObject.GetComponent<KPrefabID>()?.HasTag(GameTags.BaseMinion) ?? true)
+					continue;
+
+				if (kbac.CurrentAnim == null)
+					continue;
+
+				string currentAnim = kbac.CurrentAnim.name;
+				if (string.IsNullOrEmpty(currentAnim))
+					continue;
+
+				var wrongHash = new HashedString("fake_anim_that_doesnt_exist");
+				if (kbac.currentAnim == wrongHash)
+					return UnitTestResult.Fail("Hash collision with fake anim");
+
+				return UnitTestResult.Pass($"Minion '{id.gameObject.name}' anim='{currentAnim}', would detect mismatch");
+			}
+			return UnitTestResult.Fail("No minions with anim controller found");
+		}
+
+		[UnitTest(name: "Anim reconciliation: elapsed time readable", category: "Animation")]
+		public static UnitTestResult ElapsedTimeReadable()
+		{
+			var identities = NetworkIdentityRegistry.AllIdentities;
+			foreach (var id in identities)
+			{
+				if (!id.gameObject.TryGetComponent<KBatchedAnimController>(out var kbac))
+					continue;
+				if (!id.gameObject.GetComponent<KPrefabID>()?.HasTag(GameTags.BaseMinion) ?? true)
+					continue;
+
+				float elapsed = kbac.GetElapsedTime();
+				return UnitTestResult.Pass($"ElapsedTime={elapsed:F3}s on '{id.gameObject.name}'");
+			}
+			return UnitTestResult.Fail("No minions found");
+		}
+
+		[UnitTest(name: "Anim reconciliation: reflection helper resolves", category: "Animation")]
+		public static UnitTestResult ReflectionHelperResolves()
+		{
+			var identities = NetworkIdentityRegistry.AllIdentities;
+			foreach (var id in identities)
+			{
+				if (!id.gameObject.TryGetComponent<KBatchedAnimController>(out var kbac))
+					continue;
+
+				float before = kbac.GetElapsedTime();
+				AnimReconciliationHelper.TrySetElapsedTime(kbac, before);
+				float after = kbac.GetElapsedTime();
+
+				return UnitTestResult.Pass($"SetElapsedTime resolved. Before={before:F3}, After={after:F3}");
+			}
+			return UnitTestResult.Fail("No anim controllers found");
+		}
+
+		[UnitTest(name: "Anim sync packet: roundtrip", category: "Animation")]
+		public static UnitTestResult AnimSyncPacketRoundtrip()
+		{
+			var packet = new AnimSyncPacket
+			{
+				NetId = 42,
+				AnimHash = new HashedString("idle_loop").hash,
+				Mode = (byte)KAnim.PlayMode.Loop,
+				Speed = 1.25f,
+				ElapsedTime = 2.5f
+			};
+
+			using var ms = new MemoryStream();
+			using (var writer = new BinaryWriter(ms, System.Text.Encoding.UTF8, true))
+				packet.Serialize(writer);
+
+			ms.Position = 0;
+
+			var copy = new AnimSyncPacket();
+			using (var reader = new BinaryReader(ms, System.Text.Encoding.UTF8, true))
+				copy.Deserialize(reader);
+
+			if (copy.NetId != packet.NetId || copy.AnimHash != packet.AnimHash || copy.Mode != packet.Mode)
+				return UnitTestResult.Fail("Packet int fields did not roundtrip");
+			if (copy.Speed != packet.Speed || copy.ElapsedTime != packet.ElapsedTime)
+				return UnitTestResult.Fail("Packet float fields did not roundtrip");
+
+			return UnitTestResult.Pass("AnimSyncPacket serialize/deserialize roundtrip succeeded");
+		}
+
+		[UnitTest(name: "Anim sync: non-minion entities discoverable", category: "Animation")]
+		public static UnitTestResult NonMinionAnimEntitiesDiscoverable()
+		{
+			var identities = NetworkIdentityRegistry.AllIdentities;
+			foreach (var id in identities)
+			{
+				if (id.gameObject.GetComponent<KPrefabID>()?.HasTag(GameTags.BaseMinion) ?? false)
+					continue;
+				if (!id.gameObject.TryGetComponent<KBatchedAnimController>(out var _))
+					continue;
+				if (!id.gameObject.TryGetComponent<AnimStateSyncer>(out var _))
+					return UnitTestResult.Fail($"Entity '{id.gameObject.name}' is missing AnimStateSyncer");
+
+				return UnitTestResult.Pass($"Entity '{id.gameObject.name}' is sync-eligible");
+			}
+
+			return UnitTestResult.Fail("No non-minion animated network entities found");
+		}
+	}
+}

--- a/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
@@ -125,6 +125,8 @@ namespace ONI_MP.DebugTools.UnitTests
 					continue;
 				if (!id.gameObject.TryGetComponent<AnimStateSyncer>(out var _))
 					return UnitTestResult.Fail($"Entity '{id.gameObject.name}' is missing AnimStateSyncer");
+				if (!AnimSyncEligibility.IsAnimatedNonMinion(id.gameObject))
+					return UnitTestResult.Fail($"Entity '{id.gameObject.name}' should not have AnimStateSyncer");
 
 				return UnitTestResult.Pass($"Entity '{id.gameObject.name}' is sync-eligible");
 			}

--- a/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/AnimSyncTests.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Animation;
+using ONI_MP.Networking.Packets.Core;
+using Shared.Interfaces.Networking;
 
 namespace ONI_MP.DebugTools.UnitTests
 {
@@ -98,6 +100,17 @@ namespace ONI_MP.DebugTools.UnitTests
 				return UnitTestResult.Fail("Packet float fields did not roundtrip");
 
 			return UnitTestResult.Pass("AnimSyncPacket serialize/deserialize roundtrip succeeded");
+		}
+
+		[UnitTest(name: "Anim packets: bypass bulk queue", category: "Animation")]
+		public static UnitTestResult AnimPacketsBypassBulkQueue()
+		{
+			bool animSyncBulk = typeof(IBulkablePacket).IsAssignableFrom(typeof(AnimSyncPacket));
+			bool playAnimBulk = typeof(IBulkablePacket).IsAssignableFrom(typeof(PlayAnimPacket));
+			if (animSyncBulk || playAnimBulk)
+				return UnitTestResult.Fail("Animation packets still route through the bulk queue");
+
+			return UnitTestResult.Pass("AnimSyncPacket and PlayAnimPacket send directly");
 		}
 
 		[UnitTest(name: "Anim sync: non-minion entities discoverable", category: "Animation")]

--- a/ClassLibrary1/MultiplayerMod.cs
+++ b/ClassLibrary1/MultiplayerMod.cs
@@ -72,6 +72,7 @@ namespace ONI_MP
 				go.AddComponent<PingManager>();
 				go.AddComponent<BuildingSyncer>();
 				go.AddComponent<WorldStateSyncer>();
+				go.AddComponent<AnimSyncCoordinator>();
 				go.AddComponent<BulkPacketMonitor>();
 
 				// CHECKPOINT 5

--- a/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
+++ b/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
@@ -1,0 +1,84 @@
+using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Patches.KleiPatches;
+using System;
+using System.Reflection;
+using UnityEngine;
+
+namespace ONI_MP.Networking.Components
+{
+	/// <summary>
+	/// Static helper for setting animation elapsed time via reflection.
+	/// Used by DuplicantStatePacket for continuous animation reconciliation.
+	/// Resolves SetElapsedTime method or elapsedTime field once, then caches.
+	/// </summary>
+	internal static class AnimReconciliationHelper
+	{
+		private const float DriftThreshold = 0.15f;
+		private static MethodInfo _setElapsedTimeMethod;
+		private static FieldInfo _elapsedTimeField;
+		private static bool _resolved;
+
+		internal static void Reconcile(KBatchedAnimController kbac, HashedString animHash, KAnim.PlayMode playMode, float animSpeed, float elapsedTime, string source)
+		{
+			try
+			{
+				if (kbac.currentAnim != animHash)
+				{
+					KAnimControllerBase_Patches.AllowAnims();
+					kbac.Play(animHash, playMode, animSpeed, 0f);
+					KAnimControllerBase_Patches.ForbidAnims();
+					ForceAnimUpdate(kbac, source);
+					TrySetElapsedTime(kbac, elapsedTime);
+					return;
+				}
+
+				float localElapsed = kbac.GetElapsedTime();
+				if (Mathf.Abs(localElapsed - elapsedTime) > DriftThreshold)
+					TrySetElapsedTime(kbac, elapsedTime);
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogWarning($"[{source}] Anim reconciliation failed: {ex}");
+			}
+		}
+
+		internal static void TrySetElapsedTime(KAnimControllerBase kbac, float elapsedTime)
+		{
+			if (!_resolved)
+			{
+				_resolved = true;
+				_setElapsedTimeMethod = AccessTools.Method(typeof(KAnimControllerBase), "SetElapsedTime", [typeof(float)]);
+				if (_setElapsedTimeMethod == null)
+					_elapsedTimeField = AccessTools.Field(typeof(KAnimControllerBase), "elapsedTime");
+			}
+
+			try
+			{
+				if (_setElapsedTimeMethod != null)
+					_setElapsedTimeMethod.Invoke(kbac, [elapsedTime]);
+				else if (_elapsedTimeField != null)
+					_elapsedTimeField.SetValue(kbac, elapsedTime);
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogWarning($"[AnimReconciliationHelper] Failed to set elapsed time: {ex}");
+			}
+		}
+
+		internal static void ForceAnimUpdate(KBatchedAnimController kbac, string source)
+		{
+			try
+			{
+				kbac.SetVisiblity(true);
+				kbac.forceRebuild = true;
+				kbac.SuspendUpdates(false);
+				kbac.ConfigureUpdateListener();
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogError($"[{source}] ForceAnimUpdate failed: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
@@ -4,22 +4,18 @@ using UnityEngine;
 
 namespace ONI_MP.Networking.Components
 {
-	public class AnimStateSyncer : KMonoBehaviour, IRender1000ms
+	public class AnimStateSyncer : KMonoBehaviour
 	{
-		private const float ElapsedBucketSize = 0.15f;
-
 		[MyCmpGet]
 		private NetworkIdentity networkIdentity;
 		[MyCmpGet]
 		private KBatchedAnimController animController;
 		[MyCmpGet]
 		private KPrefabID prefabId;
+		[MyCmpGet]
+		private Operational operational;
 
-		private int _lastSentAnimHash;
-		private byte _lastSentMode;
-		private float _lastSentSpeed = 1f;
-		private int _lastSentElapsedBucket = int.MinValue;
-		private bool _hasSentSnapshot;
+		private bool _hasReceivedSnapshot;
 
 		public override void OnSpawn()
 		{
@@ -38,76 +34,95 @@ namespace ONI_MP.Networking.Components
 				enabled = false;
 				return;
 			}
+
+			AnimSyncCoordinator.Register(this);
 		}
 
-		public void Render1000ms(float dt)
+		public override void OnCleanUp()
 		{
 			using var _ = Profiler.Scope();
 
-			if (!MultiplayerSession.InSession || MultiplayerSession.IsClient)
-				return;
-
-			if (MultiplayerSession.ConnectedPlayers.Count == 0)
-				return;
-
-			SendSnapshot();
+			AnimSyncCoordinator.Unregister(this);
+			base.OnCleanUp();
 		}
 
-		private void SendSnapshot()
+		internal bool TryBuildSnapshot(out AnimSyncPacket packet, out int activityKey)
 		{
 			using var _ = Profiler.Scope();
+
+			packet = null;
+			activityKey = 0;
 
 			try
 			{
 				if (networkIdentity.NetId == 0)
 				{
-					// Late-spawned entities may not have a NetId on the first render tick.
+					// Late-spawned entities may not have a NetId on the first coordinator tick.
 					networkIdentity.RegisterIdentity();
 					if (networkIdentity.NetId == 0)
-						return;
+						return false;
 				}
 
 				if (animController.CurrentAnim == null)
-					return;
+					return false;
 
 				int animHash = animController.currentAnim.hash;
 				if (animHash == 0)
-					return;
+					return false;
 
 				byte mode = (byte)animController.mode;
 				float speed = animController.playSpeed;
-				int elapsedBucket = Mathf.RoundToInt(animController.GetElapsedTime() / ElapsedBucketSize);
+				float elapsedTime = animController.GetElapsedTime();
 
-				if (_hasSentSnapshot
-					&& animHash == _lastSentAnimHash
-					&& _lastSentMode == mode
-					&& Mathf.Approximately(_lastSentSpeed, speed)
-					&& _lastSentElapsedBucket == elapsedBucket)
-				{
-					// Only resend when the anim state changes buckets to keep per-entity traffic bounded.
-					return;
-				}
-
-				var packet = new AnimSyncPacket
+				packet = new AnimSyncPacket
 				{
 					NetId = networkIdentity.NetId,
 					AnimHash = animHash,
 					Mode = mode,
 					Speed = speed,
-					ElapsedTime = elapsedBucket * ElapsedBucketSize
+					ElapsedTime = elapsedTime
 				};
 
-				PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
-
-				_lastSentAnimHash = packet.AnimHash;
-				_lastSentMode = packet.Mode;
-				_lastSentSpeed = packet.Speed;
-				_lastSentElapsedBucket = Mathf.RoundToInt(packet.ElapsedTime / ElapsedBucketSize);
-				_hasSentSnapshot = true;
+				activityKey = BuildActivityKey(animHash, mode, speed);
+				return true;
 			}
 			catch (System.Exception)
 			{
-				// Anim state may not be ready yet.
+				return false;
+			}
+		}
+
+		public void MarkSnapshotReceived()
+		{
+			using var _ = Profiler.Scope();
+
+			_hasReceivedSnapshot = true;
+		}
+
+		private int BuildActivityKey(int animHash, byte mode, float speed)
+		{
+			using var _ = Profiler.Scope();
+
+			int operationalMask = 0;
+			if (operational != null)
+			{
+				if (operational.IsOperational)
+					operationalMask |= 1;
+				if (operational.IsActive)
+					operationalMask |= 2;
+				if (operational.IsFunctional)
+					operationalMask |= 4;
+			}
+
+			int speedKey = Mathf.RoundToInt(speed * 100f);
+
+			unchecked
+			{
+				int key = animHash;
+				key = (key * 397) ^ mode;
+				key = (key * 397) ^ speedKey;
+				key = (key * 397) ^ operationalMask;
+				return key;
 			}
 		}
 	}

--- a/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
@@ -1,0 +1,116 @@
+using ONI_MP.Networking.Packets.Animation;
+using Shared.Profiling;
+using UnityEngine;
+
+namespace ONI_MP.Networking.Components
+{
+	public class AnimStateSyncer : KMonoBehaviour
+	{
+		private const float SendInterval = 1f;
+		private const float InitialDelay = 5f;
+		private const float ElapsedBucketSize = 0.15f;
+
+		[MyCmpGet]
+		private NetworkIdentity networkIdentity;
+		[MyCmpGet]
+		private KBatchedAnimController animController;
+		[MyCmpGet]
+		private KPrefabID prefabId;
+
+		private bool _initialized;
+		private float _initializationTime;
+		private float _lastSendTime;
+		private int _lastSentAnimHash;
+		private byte _lastSentMode;
+		private float _lastSentSpeed = 1f;
+		private int _lastSentElapsedBucket = int.MinValue;
+
+		public override void OnSpawn()
+		{
+			using var _ = Profiler.Scope();
+
+			base.OnSpawn();
+
+			if (networkIdentity == null || animController == null || prefabId == null)
+			{
+				enabled = false;
+				return;
+			}
+
+			if (prefabId.HasTag(GameTags.BaseMinion))
+			{
+				enabled = false;
+				return;
+			}
+
+			if (!prefabId.HasTag(GameTags.Creature) && GetComponent<BuildingComplete>() == null)
+			{
+				enabled = false;
+				return;
+			}
+		}
+
+		private void Update()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.InSession || MultiplayerSession.IsClient)
+				return;
+
+			if (MultiplayerSession.ConnectedPlayers.Count == 0)
+				return;
+
+			if (!_initialized)
+			{
+				_initializationTime = Time.unscaledTime;
+				_initialized = true;
+				return;
+			}
+
+			if (Time.unscaledTime - _initializationTime < InitialDelay)
+				return;
+
+			float currentTime = Time.unscaledTime;
+			if (currentTime - _lastSendTime < SendInterval)
+				return;
+
+			SendSnapshot(currentTime);
+		}
+
+		private void SendSnapshot(float currentTime)
+		{
+			using var _ = Profiler.Scope();
+
+			try
+			{
+				if (animController.CurrentAnim == null)
+					return;
+
+				int animHash = animController.currentAnim.hash;
+				if (animHash == 0)
+					return;
+
+				_lastSentAnimHash = animHash;
+				_lastSentMode = (byte)animController.mode;
+				_lastSentSpeed = animController.playSpeed;
+				_lastSentElapsedBucket = Mathf.RoundToInt(animController.GetElapsedTime() / ElapsedBucketSize);
+				_lastSendTime = currentTime;
+
+				var packet = new AnimSyncPacket
+				{
+					NetId = networkIdentity.NetId,
+					AnimHash = _lastSentAnimHash,
+					Mode = _lastSentMode,
+					Speed = _lastSentSpeed,
+					ElapsedTime = _lastSentElapsedBucket * ElapsedBucketSize
+				};
+
+				PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
+			}
+			catch (System.Exception)
+			{
+				// Anim state may not be ready yet.
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
@@ -4,10 +4,8 @@ using UnityEngine;
 
 namespace ONI_MP.Networking.Components
 {
-	public class AnimStateSyncer : KMonoBehaviour
+	public class AnimStateSyncer : KMonoBehaviour, IRender1000ms
 	{
-		private const float SendInterval = 1f;
-		private const float InitialDelay = 5f;
 		private const float ElapsedBucketSize = 0.15f;
 
 		[MyCmpGet]
@@ -17,13 +15,11 @@ namespace ONI_MP.Networking.Components
 		[MyCmpGet]
 		private KPrefabID prefabId;
 
-		private bool _initialized;
-		private float _initializationTime;
-		private float _lastSendTime;
 		private int _lastSentAnimHash;
 		private byte _lastSentMode;
 		private float _lastSentSpeed = 1f;
 		private int _lastSentElapsedBucket = int.MinValue;
+		private bool _hasSentSnapshot;
 
 		public override void OnSpawn()
 		{
@@ -37,20 +33,14 @@ namespace ONI_MP.Networking.Components
 				return;
 			}
 
-			if (prefabId.HasTag(GameTags.BaseMinion))
-			{
-				enabled = false;
-				return;
-			}
-
-			if (!prefabId.HasTag(GameTags.Creature) && GetComponent<BuildingComplete>() == null)
+			if (!AnimSyncEligibility.IsAnimatedNonMinion(gameObject))
 			{
 				enabled = false;
 				return;
 			}
 		}
 
-		private void Update()
+		public void Render1000ms(float dt)
 		{
 			using var _ = Profiler.Scope();
 
@@ -60,29 +50,23 @@ namespace ONI_MP.Networking.Components
 			if (MultiplayerSession.ConnectedPlayers.Count == 0)
 				return;
 
-			if (!_initialized)
-			{
-				_initializationTime = Time.unscaledTime;
-				_initialized = true;
-				return;
-			}
-
-			if (Time.unscaledTime - _initializationTime < InitialDelay)
-				return;
-
-			float currentTime = Time.unscaledTime;
-			if (currentTime - _lastSendTime < SendInterval)
-				return;
-
-			SendSnapshot(currentTime);
+			SendSnapshot();
 		}
 
-		private void SendSnapshot(float currentTime)
+		private void SendSnapshot()
 		{
 			using var _ = Profiler.Scope();
 
 			try
 			{
+				if (networkIdentity.NetId == 0)
+				{
+					// Late-spawned entities may not have a NetId on the first render tick.
+					networkIdentity.RegisterIdentity();
+					if (networkIdentity.NetId == 0)
+						return;
+				}
+
 				if (animController.CurrentAnim == null)
 					return;
 
@@ -90,22 +74,36 @@ namespace ONI_MP.Networking.Components
 				if (animHash == 0)
 					return;
 
-				_lastSentAnimHash = animHash;
-				_lastSentMode = (byte)animController.mode;
-				_lastSentSpeed = animController.playSpeed;
-				_lastSentElapsedBucket = Mathf.RoundToInt(animController.GetElapsedTime() / ElapsedBucketSize);
-				_lastSendTime = currentTime;
+				byte mode = (byte)animController.mode;
+				float speed = animController.playSpeed;
+				int elapsedBucket = Mathf.RoundToInt(animController.GetElapsedTime() / ElapsedBucketSize);
+
+				if (_hasSentSnapshot
+					&& animHash == _lastSentAnimHash
+					&& _lastSentMode == mode
+					&& Mathf.Approximately(_lastSentSpeed, speed)
+					&& _lastSentElapsedBucket == elapsedBucket)
+				{
+					// Only resend when the anim state changes buckets to keep per-entity traffic bounded.
+					return;
+				}
 
 				var packet = new AnimSyncPacket
 				{
 					NetId = networkIdentity.NetId,
-					AnimHash = _lastSentAnimHash,
-					Mode = _lastSentMode,
-					Speed = _lastSentSpeed,
-					ElapsedTime = _lastSentElapsedBucket * ElapsedBucketSize
+					AnimHash = animHash,
+					Mode = mode,
+					Speed = speed,
+					ElapsedTime = elapsedBucket * ElapsedBucketSize
 				};
 
 				PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
+
+				_lastSentAnimHash = packet.AnimHash;
+				_lastSentMode = packet.Mode;
+				_lastSentSpeed = packet.Speed;
+				_lastSentElapsedBucket = Mathf.RoundToInt(packet.ElapsedTime / ElapsedBucketSize);
+				_hasSentSnapshot = true;
 			}
 			catch (System.Exception)
 			{

--- a/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
+++ b/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using ONI_MP.Networking.Packets.Animation;
+using Shared.Profiling;
+using UnityEngine;
+
+namespace ONI_MP.Networking.Components
+{
+	internal class AnimSyncCoordinator : MonoBehaviour
+	{
+		private class SyncState
+		{
+			public bool HasObservedState;
+			public int LastActivityKey;
+			public float LastSentTime;
+		}
+
+		private const float TickInterval = 0.2f;
+		private const int ShardCount = 5;
+		private const float SyncInterval = 1f;
+
+		private static readonly HashSet<AnimStateSyncer> TrackedSyncers = [];
+
+		public static AnimSyncCoordinator Instance { get; private set; }
+
+		private readonly Dictionary<AnimStateSyncer, SyncState> _syncStates = [];
+		private float _tickTimer;
+		private int _currentShard;
+
+		private void Awake()
+		{
+			using var _ = Profiler.Scope();
+
+			Instance = this;
+		}
+
+		private void OnDestroy()
+		{
+			using var _ = Profiler.Scope();
+
+			if (Instance == this)
+				Instance = null;
+		}
+
+		public static void Register(AnimStateSyncer syncer)
+		{
+			using var _ = Profiler.Scope();
+
+			if (syncer != null)
+				TrackedSyncers.Add(syncer);
+		}
+
+		public static void Unregister(AnimStateSyncer syncer)
+		{
+			using var _ = Profiler.Scope();
+
+			if (syncer != null)
+			{
+				TrackedSyncers.Remove(syncer);
+				Instance?._syncStates.Remove(syncer);
+			}
+		}
+
+		private void Update()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!MultiplayerSession.InSession || !MultiplayerSession.IsHost)
+				return;
+
+			if (MultiplayerSession.ConnectedPlayers.Count == 0)
+				return;
+
+			_tickTimer += Time.unscaledDeltaTime;
+			while (_tickTimer >= TickInterval)
+			{
+				_tickTimer -= TickInterval;
+				RunTick();
+			}
+		}
+
+		private void RunTick()
+		{
+			using var _ = Profiler.Scope();
+
+			var trackedSyncers = GetTrackedSyncers();
+			if (trackedSyncers.Count == 0)
+				return;
+
+			// Spread the full scan across five 200ms ticks to avoid bursty correction traffic.
+			for (int i = 0; i < trackedSyncers.Count; i++)
+			{
+				if (i % ShardCount != _currentShard)
+					continue;
+
+				ProcessSyncer(trackedSyncers[i]);
+			}
+
+			_currentShard = (_currentShard + 1) % ShardCount;
+		}
+
+		private void ProcessSyncer(AnimStateSyncer syncer)
+		{
+			using var _ = Profiler.Scope();
+
+			if (syncer == null)
+				return;
+
+			if (!syncer.TryBuildSnapshot(out var packet, out var activityKey))
+				return;
+
+			float now = Time.unscaledTime;
+			bool activityChanged = UpdateObservedState(syncer, activityKey);
+			if (!activityChanged && now - _syncStates[syncer].LastSentTime < SyncInterval)
+				return;
+
+			PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
+			_syncStates[syncer].LastSentTime = now;
+		}
+
+		private bool UpdateObservedState(AnimStateSyncer syncer, int activityKey)
+		{
+			using var _ = Profiler.Scope();
+
+			if (!_syncStates.TryGetValue(syncer, out var syncState))
+			{
+				syncState = new SyncState();
+				_syncStates[syncer] = syncState;
+			}
+
+			bool activityChanged = !syncState.HasObservedState || syncState.LastActivityKey != activityKey;
+			if (activityChanged)
+			{
+				syncState.HasObservedState = true;
+				syncState.LastActivityKey = activityKey;
+			}
+
+			return activityChanged;
+		}
+
+		private static List<AnimStateSyncer> GetTrackedSyncers()
+		{
+			using var _ = Profiler.Scope();
+
+			var syncers = new List<AnimStateSyncer>(TrackedSyncers.Count);
+			foreach (var syncer in TrackedSyncers)
+			{
+				if (syncer != null)
+					syncers.Add(syncer);
+			}
+			return syncers;
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Components/AnimSyncEligibility.cs
+++ b/ClassLibrary1/Networking/Components/AnimSyncEligibility.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace ONI_MP.Networking.Components
+{
+	internal static class AnimSyncEligibility
+	{
+		internal static bool IsAnimatedCritter(GameObject go)
+		{
+			return go != null
+				&& go.HasTag(GameTags.Creature)
+				&& !go.HasTag(GameTags.BaseMinion)
+				&& go.GetComponent<KBatchedAnimController>() != null;
+		}
+
+		internal static bool IsAnimatedBuilding(GameObject go)
+		{
+			if (go == null
+				|| go.GetComponent<BuildingComplete>() == null
+				|| go.GetComponent<KBatchedAnimController>() == null)
+			{
+				return false;
+			}
+
+			// Limit building sync to components with visible state-driven animation changes.
+			return go.GetComponent<Operational>() != null
+				|| go.GetComponent<Door>() != null
+				|| go.GetComponent<ComplexFabricator>() != null;
+		}
+
+		internal static bool IsAnimatedNonMinion(GameObject go)
+		{
+			return IsAnimatedCritter(go) || IsAnimatedBuilding(go);
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Components/DuplicantStateSender.cs
+++ b/ClassLibrary1/Networking/Components/DuplicantStateSender.cs
@@ -102,6 +102,18 @@ namespace ONI_MP.Networking.Components
 				lastSentIsWorking = isWorking;
 				lastSentHeldSymbol = heldSymbol;
 
+				int animPlayMode = 0;
+				float animSpeed = 1f;
+				try
+				{
+					if (animController != null)
+					{
+						animPlayMode = (int)animController.mode;
+						animSpeed = animController.playSpeed;
+					}
+				}
+				catch (System.Exception) { /* field not accessible, use defaults */ }
+
 				var packet = new DuplicantStatePacket
 				{
 					NetId = networkIdentity.NetId,
@@ -110,7 +122,9 @@ namespace ONI_MP.Networking.Components
 					CurrentAnimName = animName,
 					AnimElapsedTime = animElapsedTime,
 					IsWorking = isWorking,
-					HeldItemSymbol = heldSymbol
+					HeldItemSymbol = heldSymbol,
+					AnimPlayMode = animPlayMode,
+					AnimSpeed = animSpeed
 				};
 
 				PacketSender.SendToAllClients(packet, sendType: PacketSendMode.Unreliable);

--- a/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
@@ -55,6 +55,9 @@ namespace ONI_MP.Networking.Packets.Animation
 				Speed,
 				ElapsedTime,
 				nameof(AnimSyncPacket));
+
+			if (kbac.TryGetComponent<AnimStateSyncer>(out var syncer))
+				syncer.MarkSnapshotReceived();
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
@@ -1,0 +1,65 @@
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Interfaces.Networking;
+using Shared.Profiling;
+using System.IO;
+
+namespace ONI_MP.Networking.Packets.Animation
+{
+	internal class AnimSyncPacket : IPacket, IBulkablePacket
+	{
+		public int NetId;
+		public int AnimHash;
+		public byte Mode;
+		public float Speed;
+		public float ElapsedTime;
+
+		public int MaxPackSize => 1;
+
+		public uint IntervalMs => 1000;
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write(NetId);
+			writer.Write(AnimHash);
+			writer.Write(Mode);
+			writer.Write(Speed);
+			writer.Write(ElapsedTime);
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			NetId = reader.ReadInt32();
+			AnimHash = reader.ReadInt32();
+			Mode = reader.ReadByte();
+			Speed = reader.ReadSingle();
+			ElapsedTime = reader.ReadSingle();
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (MultiplayerSession.IsHost)
+				return;
+
+			if (AnimHash == 0)
+				return;
+
+			if (!NetworkIdentityRegistry.TryGetComponent<KBatchedAnimController>(NetId, out var kbac))
+				return;
+
+			AnimReconciliationHelper.Reconcile(
+				kbac,
+				new HashedString(AnimHash),
+				(KAnim.PlayMode)Mode,
+				Speed,
+				ElapsedTime,
+				nameof(AnimSyncPacket));
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/AnimSyncPacket.cs
@@ -1,22 +1,17 @@
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
-using Shared.Interfaces.Networking;
 using Shared.Profiling;
 using System.IO;
 
 namespace ONI_MP.Networking.Packets.Animation
 {
-	internal class AnimSyncPacket : IPacket, IBulkablePacket
+	internal class AnimSyncPacket : IPacket
 	{
 		public int NetId;
 		public int AnimHash;
 		public byte Mode;
 		public float Speed;
 		public float ElapsedTime;
-
-		public int MaxPackSize => 1;
-
-		public uint IntervalMs => 1000;
 
 		public void Serialize(BinaryWriter writer)
 		{

--- a/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
@@ -3,7 +3,6 @@ using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
 using ONI_MP.Patches.KleiPatches;
-using Shared.Interfaces.Networking;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,7 +11,7 @@ using System.Reflection;
 using Shared.Profiling;
 using UnityEngine;
 
-public class PlayAnimPacket : IPacket, IBulkablePacket
+public class PlayAnimPacket : IPacket
 {
 
 	public PlayAnimPacket() { }
@@ -30,17 +29,13 @@ public class PlayAnimPacket : IPacket, IBulkablePacket
 	}
 
 	public int NetId;
-	public float TimeStamp;
+	public long TimeStamp;
 	public HashedString[] AnimHashes = [];
 	public KAnim.PlayMode Mode;
 	public float Speed;
 	public float TimeOffset;
 	public bool IsQueue; // Supports Queue()
 	bool MultipleAnims => AnimHashes.Count() > 1;
-
-    public int MaxPackSize => 500;
-
-    public uint IntervalMs => 50;
 
     public void Serialize(BinaryWriter writer)
 	{
@@ -63,7 +58,7 @@ public class PlayAnimPacket : IPacket, IBulkablePacket
 		using var _ = Profiler.Scope();
 
 		NetId = reader.ReadInt32();
-		TimeStamp = reader.ReadSingle();
+		TimeStamp = reader.ReadInt64();
 		Mode = (KAnim.PlayMode)reader.ReadInt32();
 		Speed = reader.ReadSingle();
 		TimeOffset = reader.ReadSingle();
@@ -75,7 +70,7 @@ public class PlayAnimPacket : IPacket, IBulkablePacket
 			AnimHashes[i] = new HashedString(reader.ReadInt32());
 	}
 
-	Dictionary<int, float> LastIdUpdates = [];
+	private static readonly Dictionary<int, long> LastIdUpdates = [];
 
 	public void OnDispatched()
 	{
@@ -87,6 +82,7 @@ public class PlayAnimPacket : IPacket, IBulkablePacket
 		if (!NetworkIdentityRegistry.TryGet(NetId, out var go))
 			return;
 
+		// Keep the last event time per entity so older anim packets cannot rewind newer state.
 		if (LastIdUpdates.TryGetValue(NetId, out var lastTimeStamp) && lastTimeStamp > TimeStamp)
 			return;
 		LastIdUpdates[NetId] = TimeStamp;

--- a/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
@@ -137,6 +137,8 @@ public class PlayAnimPacket : IPacket
 
 		}
 		ForceAnimUpdate(kbac);
+		if (go.TryGetComponent<AnimStateSyncer>(out var syncer))
+			syncer.MarkSnapshotReceived();
 		// Force updates for animation to tick properly
 	}
 

--- a/ClassLibrary1/Networking/Packets/DuplicantActions/DuplicantStatePacket.cs
+++ b/ClassLibrary1/Networking/Packets/DuplicantActions/DuplicantStatePacket.cs
@@ -1,4 +1,4 @@
-using ONI_MP.DebugTools;
+using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
 using System.IO;
 using Shared.Profiling;
@@ -8,6 +8,7 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 	/// <summary>
 	/// Synchronizes high-level duplicant state (action type, work target, etc.)
 	/// This helps clients understand what the duplicant is doing beyond just animations.
+	/// Includes continuous animation reconciliation to self-correct desync.
 	/// </summary>
 	public class DuplicantStatePacket : IPacket
 	{
@@ -17,7 +18,9 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 		public string CurrentAnimName;  // specific animation override
 		public float AnimElapsedTime;   // Elapsed time in current animation
 		public bool IsWorking;          // Whether actively working on something
-		public string HeldItemSymbol; // For syncing guns/tools/carryables current animation
+		public string HeldItemSymbol;   // For syncing guns/tools/carryables current animation
+		public int AnimPlayMode;        // KAnim.PlayMode for continuous anim reconciliation
+		public float AnimSpeed;         // Playback speed for continuous anim reconciliation
 
 		public void Serialize(BinaryWriter writer)
 		{
@@ -30,6 +33,8 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 			writer.Write(AnimElapsedTime);
 			writer.Write(IsWorking);
 			writer.Write(HeldItemSymbol ?? string.Empty);
+			writer.Write(AnimPlayMode);
+			writer.Write(AnimSpeed);
 		}
 
 		public void Deserialize(BinaryReader reader)
@@ -37,12 +42,14 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 			using var _ = Profiler.Scope();
 
 			NetId = reader.ReadInt32();
-			ActionState = (DuplicantActionState)reader.ReadInt32(); // Changed to Int32 to match Serialize
+			ActionState = (DuplicantActionState)reader.ReadInt32();
 			TargetCell = reader.ReadInt32();
 			CurrentAnimName = reader.ReadString();
 			AnimElapsedTime = reader.ReadSingle();
 			IsWorking = reader.ReadBoolean();
 			HeldItemSymbol = reader.ReadString();
+			AnimPlayMode = reader.ReadInt32();
+			AnimSpeed = reader.ReadSingle();
 		}
 
 		public void OnDispatched()
@@ -52,6 +59,19 @@ namespace ONI_MP.Networking.Packets.DuplicantActions
 			if (MultiplayerSession.IsHost)
 				return;
 
+			if (!NetworkIdentityRegistry.TryGetComponent<KBatchedAnimController>(NetId, out var kbac))
+				return;
+
+			if (string.IsNullOrEmpty(CurrentAnimName))
+				return;
+
+			AnimReconciliationHelper.Reconcile(
+				kbac,
+				new HashedString(CurrentAnimName),
+				(KAnim.PlayMode)AnimPlayMode,
+				AnimSpeed,
+				AnimElapsedTime,
+				nameof(DuplicantStatePacket));
 		}
 	}
 

--- a/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
+++ b/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
@@ -11,28 +11,31 @@ using UnityEngine;
 
 namespace ONI_MP.Patches.Critters
 {
-    internal class EntityTemplatesPatch
-    {
-        [HarmonyPatch(typeof(EntityTemplates), nameof(EntityTemplates.ExtendEntityToBasicCreature), new Type[] { typeof(bool), typeof(GameObject), typeof(string), typeof(string), typeof(string), typeof(FactionManager.FactionID), typeof(string), typeof(string), typeof(NavType), typeof(int), typeof(float), typeof(string), typeof(float), typeof(bool), typeof(bool), typeof(float), typeof(float), typeof(float), typeof(float) })]
-        public static class ExtendEntityToBasicCreature_Patch
-        {
-            public static void Postfix(GameObject __result)
-            {
-                using var _ = Profiler.Scope();
+	internal class EntityTemplatesPatch
+	{
+		[HarmonyPatch(typeof(EntityTemplates), nameof(EntityTemplates.ExtendEntityToBasicCreature), new Type[] { typeof(bool), typeof(GameObject), typeof(string), typeof(string), typeof(string), typeof(FactionManager.FactionID), typeof(string), typeof(string), typeof(NavType), typeof(int), typeof(float), typeof(string), typeof(float), typeof(bool), typeof(bool), typeof(float), typeof(float), typeof(float), typeof(float) })]
+		public static class ExtendEntityToBasicCreature_Patch
+		{
+			public static void Postfix(GameObject __result)
+			{
+				using var _ = Profiler.Scope();
 
-                if (__result == null)
-                    return;
+				if (__result == null)
+					return;
 
-                var KPrefabID = __result.TryGetComponent<KPrefabID>(out var pid) ? pid.PrefabTag.ToString() : "NO KPrefabID";
+				if (!__result.HasTag(GameTags.Creature))
+					return;
 
-                if (!__result.HasTag(GameTags.Creature)) // I don't expect this to trigger ever
-                    return;
+				__result.AddOrGet<EntityPositionHandler>();
 
-                if (__result.GetComponent<EntityPositionHandler>() != null)
-                    return;
+				var kbac = __result.GetComponent<KBatchedAnimController>();
+				if (kbac == null)
+					return;
 
-                __result.AddOrGet<EntityPositionHandler>();
-            }
-        }
-    }
+				var identity = __result.AddOrGet<NetworkIdentity>();
+				identity.RegisterIdentity();
+				__result.AddOrGet<AnimStateSyncer>();
+			}
+		}
+	}
 }

--- a/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
+++ b/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
@@ -23,17 +23,11 @@ namespace ONI_MP.Patches.Critters
 				if (__result == null)
 					return;
 
-				if (!__result.HasTag(GameTags.Creature))
+				if (!AnimSyncEligibility.IsAnimatedCritter(__result))
 					return;
 
 				__result.AddOrGet<EntityPositionHandler>();
-
-				var kbac = __result.GetComponent<KBatchedAnimController>();
-				if (kbac == null)
-					return;
-
-				var identity = __result.AddOrGet<NetworkIdentity>();
-				identity.RegisterIdentity();
+				__result.AddOrGet<NetworkIdentity>();
 				__result.AddOrGet<AnimStateSyncer>();
 			}
 		}

--- a/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
+++ b/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
@@ -21,6 +21,7 @@ namespace ONI_MP.Patches.World
 			// Let's focus on BuildingComplete for settings sync.
 			if (!(__instance is BuildingComplete)) return;
 
+			bool hasAnimController = go.GetComponent<KBatchedAnimController>() != null;
 			bool needsIdentity = false;
 
 			// Check for components that require NetID
@@ -39,6 +40,7 @@ namespace ONI_MP.Patches.World
 			else if (go.GetComponent<StorageLocker>() != null) needsIdentity = true;
 			else if (go.GetComponent<Refrigerator>() != null) needsIdentity = true;
 			else if (go.GetComponent<RationBox>() != null) needsIdentity = true;
+			else if (hasAnimController) needsIdentity = true;
 
 			if (needsIdentity)
 			{
@@ -47,6 +49,9 @@ namespace ONI_MP.Patches.World
 				// even if the component was already there but not registered.
 				identity.RegisterIdentity();
 			}
+
+			if (hasAnimController)
+				go.AddOrGet<AnimStateSyncer>();
 		}
 	}
 }

--- a/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
+++ b/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
@@ -21,7 +21,7 @@ namespace ONI_MP.Patches.World
 			// Let's focus on BuildingComplete for settings sync.
 			if (!(__instance is BuildingComplete)) return;
 
-			bool hasAnimController = go.GetComponent<KBatchedAnimController>() != null;
+			bool isAnimatedBuildingCandidate = AnimSyncEligibility.IsAnimatedBuilding(go);
 			bool needsIdentity = false;
 
 			// Check for components that require NetID
@@ -40,7 +40,7 @@ namespace ONI_MP.Patches.World
 			else if (go.GetComponent<StorageLocker>() != null) needsIdentity = true;
 			else if (go.GetComponent<Refrigerator>() != null) needsIdentity = true;
 			else if (go.GetComponent<RationBox>() != null) needsIdentity = true;
-			else if (hasAnimController) needsIdentity = true;
+			else if (isAnimatedBuildingCandidate) needsIdentity = true;
 
 			if (needsIdentity)
 			{
@@ -49,9 +49,6 @@ namespace ONI_MP.Patches.World
 				// even if the component was already there but not registered.
 				identity.RegisterIdentity();
 			}
-
-			if (hasAnimController)
-				go.AddOrGet<AnimStateSyncer>();
 		}
 	}
 }

--- a/ClassLibrary1/Patches/World/Buildings/BuildingComplete_Patches.cs
+++ b/ClassLibrary1/Patches/World/Buildings/BuildingComplete_Patches.cs
@@ -20,6 +20,9 @@ namespace ONI_MP.Patches.World.Buildings
                 using var _ = Profiler.Scope();
 
                 __instance.gameObject.AddOrGet<NetworkIdentity>();
+
+				if (AnimSyncEligibility.IsAnimatedBuilding(__instance.gameObject))
+					__instance.gameObject.AddOrGet<AnimStateSyncer>();
             }
         }
 	}

--- a/animation_sync_spec.md
+++ b/animation_sync_spec.md
@@ -1,0 +1,120 @@
+# ANIMATION SYNC - FULL CHANGE SPECIFICATION
+
+## 1. OVERVIEW
+
+```text
+BEFORE:
+  Host -> PlayAnimPacket -> Client
+  If the packet drops, the client can stay on the wrong animation forever.
+
+AFTER:
+  Minions:
+    Host -> PlayAnimPacket -> Client        (event-driven, unchanged)
+    Host -> DuplicantStatePacket -> Client  every 200ms
+
+  Critters:
+    Host -> PlayAnimPacket -> Client        (event-driven once they have NetId)
+    Host -> AnimSyncPacket -> Client        every 1000ms
+
+  Animated buildings:
+    Host -> AnimSyncPacket -> Client        every 1000ms
+```
+
+This change stays inside the author's current state-sync model. It adds periodic animation reconciliation on top of existing event-driven packets. It does not touch the transport layer, does not change `BuildingSyncer`, and does not revive `DuplicantClientController` or `NavigatorTransitionPacket`.
+
+## 2. SCOPE MATRIX
+
+| Entity type | Event-driven packet | Periodic packet | Interval |
+|-------------|---------------------|-----------------|----------|
+| Minions | `PlayAnimPacket` | `DuplicantStatePacket` | 200ms |
+| Critters | `PlayAnimPacket` | `AnimSyncPacket` | 1000ms |
+| Animated buildings | none | `AnimSyncPacket` | 1000ms |
+
+Only entities with both `NetworkIdentity` and `KBatchedAnimController` participate. Buildings are included only when they are animated and network-identifiable.
+
+## 3. PACKET CHANGES
+
+### `DuplicantStatePacket` (minions, every 200ms)
+
+`DuplicantStatePacket` keeps its existing high-level duplicant state fields and now also carries:
+
+- `AnimPlayMode` (`int`)
+- `AnimSpeed` (`float`)
+
+Minion reconciliation uses:
+
+- `CurrentAnimName`
+- `AnimElapsedTime`
+- `AnimPlayMode`
+- `AnimSpeed`
+
+This branch keeps the current packet-shape change as-is. Host and clients must run the same mod version. No handshake/version-gating is added in this increment.
+
+### `AnimSyncPacket` (critters and animated buildings, every 1000ms)
+
+`AnimSyncPacket` is a compact periodic reconciliation packet:
+
+- `NetId` (`int`)
+- `AnimHash` (`int`)
+- `Mode` (`byte`)
+- `Speed` (`float`)
+- `ElapsedTime` (`float`)
+
+The packet implements `IBulkablePacket` and is emitted by a new host-side `AnimStateSyncer` component attached only to eligible non-minion animated entities.
+
+## 4. RECONCILIATION RULES
+
+Both packet paths use the same reconciliation policy:
+
+1. If the client's current animation differs from the authoritative animation, replay the authoritative animation with the packet's mode and speed, then snap elapsed time.
+2. If the animation matches but elapsed-time drift exceeds 150ms, snap elapsed time.
+3. If the animation matches and drift is within 150ms, do nothing.
+
+`Mode` and `Speed` are authoritative replay parameters in this increment. They are not treated as standalone mismatch triggers when the current animation already matches.
+
+## 5. ARCHITECTURE FIT
+
+- This is state reconciliation, not lockstep.
+- The host remains authoritative.
+- The transport layer stays untouched.
+- `BuildingSyncer` keeps its existing 30s full-state building reconciliation behavior.
+- `PlayAnimPacket` stays event-driven and unchanged as a class.
+- `DuplicantClientController` remains commented out.
+- `NavigatorTransitionPacket` remains commented out.
+
+## 6. FILES IN THIS CHANGE
+
+- `DuplicantStatePacket.cs`
+  - Uses shared reconciliation logic for minions.
+  - Keeps `AnimPlayMode` and `AnimSpeed`.
+- `DuplicantStateSender.cs`
+  - Continues to populate minion animation state every 200ms.
+- `AnimReconciliationHelper.cs`
+  - Resolves elapsed-time setters once.
+  - Applies shared replay/drift correction logic.
+- `AnimSyncPacket.cs`
+  - New periodic non-minion animation reconciliation packet.
+- `AnimStateSyncer.cs`
+  - New host-side sender for critters and animated buildings.
+- `EntityTemplatesPatch.cs`
+  - Gives animated critters `NetworkIdentity` and `AnimStateSyncer`.
+- `BuildingSpawnPatch.cs`
+  - Gives animated buildings `NetworkIdentity` and `AnimStateSyncer`.
+- `AnimSyncTests.cs`
+  - Covers reconciliation helper behavior, packet roundtrip, and non-minion sync eligibility.
+
+## 7. KNOWN LIMITATIONS
+
+- Transition-driver position offsets remain out of scope.
+- This increment does not restore client-side transition playback controllers.
+- If reflection-based elapsed-time restore fails, the client falls back to current event-driven behavior.
+- Buildings use periodic reconciliation only in this increment. Immediate event-driven building animation sync is not added here.
+
+## 8. ACCEPTANCE
+
+- Minion wrong-animation desync self-heals within one 200ms heartbeat plus render delay.
+- Critter wrong-animation desync self-heals within one 1000ms sync interval.
+- Animated-building wrong-animation desync self-heals within one 1000ms sync interval.
+- Drift-only desync snaps elapsed time without replaying a different animation.
+- Entities without `NetworkIdentity` or `KBatchedAnimController` fail closed with no crash.
+- Join-in-progress clients converge without re-enabling transition playback code.

--- a/animation_sync_spec.md
+++ b/animation_sync_spec.md
@@ -9,8 +9,9 @@ BEFORE:
 
 AFTER:
   Minions:
-    Host -> PlayAnimPacket -> Client        (event-driven, unchanged)
-    Host -> DuplicantStatePacket -> Client  every 200ms
+    Host -> PlayAnimPacket -> Client        (event-driven direct send)
+    Host -> DuplicantStatePacket -> Client  on 200ms state checks
+    Host -> DuplicantStatePacket -> Client  forced heartbeat every 1000ms
 
   Critters:
     Host -> PlayAnimPacket -> Client        (event-driven once they have NetId)
@@ -26,11 +27,11 @@ This change stays inside the author's current state-sync model. It adds periodic
 
 | Entity type | Event-driven packet | Periodic packet | Interval |
 |-------------|---------------------|-----------------|----------|
-| Minions | `PlayAnimPacket` | `DuplicantStatePacket` | 200ms |
+| Minions | `PlayAnimPacket` | `DuplicantStatePacket` | 200ms checks, 1000ms heartbeat |
 | Critters | `PlayAnimPacket` | `AnimSyncPacket` | 1000ms |
 | Animated buildings | none | `AnimSyncPacket` | 1000ms |
 
-Only entities with both `NetworkIdentity` and `KBatchedAnimController` participate. Buildings are included only when they are animated and network-identifiable.
+Only entities with both `NetworkIdentity` and `KBatchedAnimController` participate. Buildings are included only when they are animated, network-identifiable, and known to switch between active/inactive-style animations.
 
 ## 3. PACKET CHANGES
 
@@ -48,11 +49,11 @@ Minion reconciliation uses:
 - `AnimPlayMode`
 - `AnimSpeed`
 
-This branch keeps the current packet-shape change as-is. Host and clients must run the same mod version. No handshake/version-gating is added in this increment.
+This branch keeps the current packet-shape change as-is. Host and clients must run the same mod version. If the protocol-gating branch lands first, animation packets inherit that verification automatically.
 
 ### `AnimSyncPacket` (critters and animated buildings, every 1000ms)
 
-`AnimSyncPacket` is a compact periodic reconciliation packet:
+`AnimSyncPacket` is a compact periodic reconciliation packet sent directly as `Unreliable`:
 
 - `NetId` (`int`)
 - `AnimHash` (`int`)
@@ -60,7 +61,7 @@ This branch keeps the current packet-shape change as-is. Host and clients must r
 - `Speed` (`float`)
 - `ElapsedTime` (`float`)
 
-The packet implements `IBulkablePacket` and is emitted by a new host-side `AnimStateSyncer` component attached only to eligible non-minion animated entities.
+The packet is emitted by a host-side `AnimStateSyncer` component attached only to eligible non-minion animated entities.
 
 ## 4. RECONCILIATION RULES
 
@@ -78,9 +79,10 @@ Both packet paths use the same reconciliation policy:
 - The host remains authoritative.
 - The transport layer stays untouched.
 - `BuildingSyncer` keeps its existing 30s full-state building reconciliation behavior.
-- `PlayAnimPacket` stays event-driven and unchanged as a class.
+- `PlayAnimPacket` stays event-driven but bypasses the broken bulk path so it preserves the requested send semantics.
 - `DuplicantClientController` remains commented out.
 - `NavigatorTransitionPacket` remains commented out.
+- The client still runs local animation code; periodic reconciliation is the safety net instead of a hard client-side animation gate.
 
 ## 6. FILES IN THIS CHANGE
 
@@ -88,20 +90,23 @@ Both packet paths use the same reconciliation policy:
   - Uses shared reconciliation logic for minions.
   - Keeps `AnimPlayMode` and `AnimSpeed`.
 - `DuplicantStateSender.cs`
-  - Continues to populate minion animation state every 200ms.
+  - Continues 200ms state checks and keeps a 1000ms forced heartbeat.
 - `AnimReconciliationHelper.cs`
   - Resolves elapsed-time setters once.
   - Applies shared replay/drift correction logic.
 - `AnimSyncPacket.cs`
-  - New periodic non-minion animation reconciliation packet.
+  - New periodic non-minion animation reconciliation packet sent directly as `Unreliable`.
 - `AnimStateSyncer.cs`
-  - New host-side sender for critters and animated buildings.
+  - Host-side sender for critters and selected animated buildings.
+  - Uses `IRender1000ms` and cached state instead of per-frame `Update()`.
 - `EntityTemplatesPatch.cs`
-  - Gives animated critters `NetworkIdentity` and `AnimStateSyncer`.
+  - Gives animated critter prefabs `NetworkIdentity` and `AnimStateSyncer` without template-time registration.
 - `BuildingSpawnPatch.cs`
-  - Gives animated buildings `NetworkIdentity` and `AnimStateSyncer`.
+  - Registers identities for selected animated building instances.
+- `BuildingComplete_Patches.cs`
+  - Attaches `AnimStateSyncer` to eligible building prefabs so instance lifecycle stays correct.
 - `AnimSyncTests.cs`
-  - Covers reconciliation helper behavior, packet roundtrip, and non-minion sync eligibility.
+  - Covers reconciliation helper behavior, packet roundtrip, direct-send packet shape, and non-minion sync eligibility.
 
 ## 7. KNOWN LIMITATIONS
 
@@ -109,12 +114,13 @@ Both packet paths use the same reconciliation policy:
 - This increment does not restore client-side transition playback controllers.
 - If reflection-based elapsed-time restore fails, the client falls back to current event-driven behavior.
 - Buildings use periodic reconciliation only in this increment. Immediate event-driven building animation sync is not added here.
+- Same-animation `Mode`/`Speed` mismatch is still corrected on replay, not treated as an independent mismatch trigger.
 
 ## 8. ACCEPTANCE
 
-- Minion wrong-animation desync self-heals within one 200ms heartbeat plus render delay.
-- Critter wrong-animation desync self-heals within one 1000ms sync interval.
-- Animated-building wrong-animation desync self-heals within one 1000ms sync interval.
+- Minion wrong-animation desync self-heals on the next state-changing packet or within one 1000ms heartbeat.
+- Critter wrong-animation desync self-heals within one 1000ms sync interval with no 5s warmup delay.
+- Animated-building wrong-animation desync self-heals within one 1000ms sync interval with no 5s warmup delay.
 - Drift-only desync snaps elapsed time without replaying a different animation.
 - Entities without `NetworkIdentity` or `KBatchedAnimController` fail closed with no crash.
 - Join-in-progress clients converge without re-enabling transition playback code.


### PR DESCRIPTION
## Summary
- replace per-entity non-minion anim heartbeats with a shared host-side coordinator
- turn `AnimStateSyncer` into a lightweight snapshot provider
- mark authoritative anim packets as received on the client
- keep the change focused on scheduler core behavior

## Verification
- `dotnet build Oni_MP.sln -c Debug`

## Notes
- this is the first step in reducing non-minion animation traffic
- visibility gating and client resync requests stay in follow-up PRs
- this draft also carries the existing animation sync foundation because `0.5.1` does not yet contain those prerequisite changes

## Runtime Validation
- [ ] Steam host + 1 client smoke validation
- [ ] LAN host + 1 client smoke validation
