### PR TITLE
Fix Riptide server-side timeout causing first-join disconnects

### DIFF
--- a/ClassLibrary1/Networking/Transport/Riptide/RiptideServer.cs
+++ b/ClassLibrary1/Networking/Transport/Riptide/RiptideServer.cs
@@ -61,6 +61,7 @@ namespace ONI_MP.Networking.Transport.Lan
             int maxClients = Configuration.Instance.Host.MaxLobbySize;
 
             _server = new Server("Lan/Riptide");
+            _server.TimeoutTime = 30000;
             _server.MessageReceived += OnServerMessageReceived;
             _server.ConnectionFailed += OnClientConnectionFailed;
             _server.ClientConnected += ServerOnClientConnected;


### PR DESCRIPTION
- Riptide's default server timeout is 5s, client was set to 30s
- Server checks timeouts before processing incoming heartbeats, so any frame spike > 5s kills the connection
- Now both sides use 30s