### PR TITLE
fix(anim-sync): bound bandwidth bursts and retry floods

### DIFF
--- a/ClassLibrary1/DebugTools/SyncStats.cs
+++ b/ClassLibrary1/DebugTools/SyncStats.cs
@@ -33,6 +33,12 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric Structures = new SyncMetric { Name = "Structures", Interval = 0.5f };
 		public static SyncMetric VitalStats = new SyncMetric { Name = "VitalStats", Interval = 1f };
 		public static SyncMetric Plants = new SyncMetric { Name = "Plants", Interval = 5f };
+		// AnimSync: host-side per-entity visible-path sends (activity-triggered + interval).
+		// LastItemCount = recipients in last send; LastPacketBytes = snapshot bytes.
+		public static SyncMetric AnimSync = new SyncMetric { Name = "AnimSync", Interval = 5f };
+		// AnimResyncRequest: client-side resync-request packets (count = NetIds requested,
+		// bytes = packet size, durationMs = current retry interval in ms for easy log read).
+		public static SyncMetric AnimResyncRequest = new SyncMetric { Name = "AnimResyncReq", Interval = 5f };
 
 		/// <summary>
 		/// Updates a metric after a sync operation.
@@ -53,7 +59,8 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric[] AllMetrics => new[]
 		{
 			Gas, Digging, Chores, Research,
-			Buildings, Structures, VitalStats, Plants
+			Buildings, Structures, VitalStats, Plants,
+			AnimSync, AnimResyncRequest
 		};
 	}
 }

--- a/ClassLibrary1/Misc/Utils.cs
+++ b/ClassLibrary1/Misc/Utils.cs
@@ -171,6 +171,23 @@ namespace ONI_MP.Misc
 				return false;
 			return true;
 		}
+		/// <summary>
+		/// Gate for host-originated broadcasts that key off NetId on the wire.
+		/// True only if: in session, is host, behavior alive, attached GameObject has a
+		/// NetworkIdentity with NetId != 0. Rejects ghost/preview/particle GameObjects
+		/// that use shared Klei components (e.g. SymbolOverrideController) but are not
+		/// registered network entities — sending for them would be wasted bandwidth
+		/// (receiver lookup would fail anyway).
+		/// </summary>
+		public static bool IsHostEntityWithNetId(MonoBehaviour behavior, out int netId)
+		{
+			using var _ = Profiler.Scope();
+			netId = 0;
+			if (!IsHostEntity(behavior))
+				return false;
+			netId = behavior.GetNetId();
+			return netId != 0;
+		}
 		public static bool IsHostEntity(MonoBehaviour behavior)
 		{
 			using var _ = Profiler.Scope();

--- a/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
+++ b/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
@@ -26,8 +26,15 @@ namespace ONI_MP.Networking.Components
 				if (kbac.currentAnim != animHash)
 				{
 					KAnimControllerBase_Patches.AllowAnims();
-					kbac.Play(animHash, playMode, animSpeed, 0f);
-					KAnimControllerBase_Patches.ForbidAnims();
+					try
+					{
+						kbac.Play(animHash, playMode, animSpeed, 0f);
+					}
+					finally
+					{
+						// Invariant #10: a throw in Play must not leak globally-allowed anims.
+						KAnimControllerBase_Patches.ForbidAnims();
+					}
 					ForceAnimUpdate(kbac, source);
 					TrySetElapsedTime(kbac, elapsedTime);
 					return;

--- a/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
+++ b/ClassLibrary1/Networking/Components/AnimReconciliationHelper.cs
@@ -18,6 +18,7 @@ namespace ONI_MP.Networking.Components
 		private static MethodInfo _setElapsedTimeMethod;
 		private static FieldInfo _elapsedTimeField;
 		private static bool _resolved;
+		private static bool _missingSetterLogged;
 
 		internal static void Reconcile(KBatchedAnimController kbac, HashedString animHash, KAnim.PlayMode playMode, float animSpeed, float elapsedTime, string source)
 		{
@@ -66,6 +67,11 @@ namespace ONI_MP.Networking.Components
 					_setElapsedTimeMethod.Invoke(kbac, [elapsedTime]);
 				else if (_elapsedTimeField != null)
 					_elapsedTimeField.SetValue(kbac, elapsedTime);
+				else if (!_missingSetterLogged)
+				{
+					_missingSetterLogged = true;
+					DebugConsole.LogWarning("[AnimReconciliationHelper] Failed to resolve elapsed-time setter; animation drift correction will be disabled");
+				}
 			}
 			catch (Exception ex)
 			{

--- a/ClassLibrary1/Networking/Components/AnimResyncRequester.cs
+++ b/ClassLibrary1/Networking/Components/AnimResyncRequester.cs
@@ -9,12 +9,21 @@ namespace ONI_MP.Networking.Components
 	internal class AnimResyncRequester : MonoBehaviour
 	{
 		private const float InitialRequestDelay = 1f;
-		private const float RetryInterval = 5f;
+		private const float RetryIntervalBase = 5f;
+		private const float RetryIntervalMax = 30f;
+		// Per-NetId cooldown prevents the same entity from being requested
+		// every retry tick when the host silently drops responses.
+		private const float PerNetIdCooldown = 15f;
+		// Hard cap on NetIds per AnimResyncRequestPacket. Unreliable UDP
+		// fragments silently when the payload exceeds MTU.
+		private const int MaxNetIdsPerPacket = 64;
 
 		private bool _subscribed;
 		private bool _initialRequestSent;
 		private float _nextInitialRequestTime = float.MaxValue;
 		private float _lastRetryTime;
+		private float _retryInterval = RetryIntervalBase;
+		private readonly Dictionary<int, float> _lastRequestTime = [];
 
 		private void Update()
 		{
@@ -27,6 +36,8 @@ namespace ONI_MP.Networking.Components
 			{
 				_initialRequestSent = false;
 				_nextInitialRequestTime = float.MaxValue;
+				_retryInterval = RetryIntervalBase;
+				_lastRequestTime.Clear();
 				return;
 			}
 
@@ -41,10 +52,14 @@ namespace ONI_MP.Networking.Components
 				_lastRetryTime = now;
 			}
 
-			if (_initialRequestSent && now - _lastRetryTime >= RetryInterval)
+			if (_initialRequestSent && now - _lastRetryTime >= _retryInterval)
 			{
-				RequestVisibleAnimations(false);
+				bool sentAny = RequestVisibleAnimations(false);
 				_lastRetryTime = now;
+				// Exponential backoff while the host keeps dropping or ignoring
+				// our requests; reset on the next fresh session or scheduling.
+				if (sentAny)
+					_retryInterval = Mathf.Min(_retryInterval * 1.5f, RetryIntervalMax);
 			}
 		}
 
@@ -64,6 +79,8 @@ namespace ONI_MP.Networking.Components
 			_initialRequestSent = false;
 			_nextInitialRequestTime = Time.unscaledTime + InitialRequestDelay;
 			_lastRetryTime = 0f;
+			_retryInterval = RetryIntervalBase;
+			_lastRequestTime.Clear();
 		}
 
 		private bool RequestVisibleAnimations(bool includeAllVisible)
@@ -73,7 +90,8 @@ namespace ONI_MP.Networking.Components
 			if (!WorldStateSyncer.TryGetLocalViewport(out var viewport, 2))
 				return false;
 
-			var requestedNetIds = new HashSet<int>();
+			float now = Time.unscaledTime;
+			var requestedNetIds = new List<int>();
 			foreach (var syncer in AnimSyncCoordinator.GetTrackedSyncers())
 			{
 				if (syncer == null || !syncer.IsVisibleIn(viewport))
@@ -84,7 +102,16 @@ namespace ONI_MP.Networking.Components
 				if (syncer.NetId == 0)
 					continue;
 
+				// Per-NetId cooldown: do not re-request the same entity faster than
+				// the host can reasonably respond; avoids flood when responses drop.
+				if (_lastRequestTime.TryGetValue(syncer.NetId, out var last) && now - last < PerNetIdCooldown)
+					continue;
+
 				requestedNetIds.Add(syncer.NetId);
+				_lastRequestTime[syncer.NetId] = now;
+
+				if (requestedNetIds.Count >= MaxNetIdsPerPacket)
+					break;
 			}
 
 			if (requestedNetIds.Count > 0)
@@ -94,9 +121,10 @@ namespace ONI_MP.Networking.Components
 					RequesterId = MultiplayerSession.LocalUserID,
 					NetIds = [.. requestedNetIds]
 				}, PacketSendMode.Unreliable);
+				return true;
 			}
 
-			return true;
+			return false;
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Components/AnimResyncRequester.cs
+++ b/ClassLibrary1/Networking/Components/AnimResyncRequester.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using ONI_MP.DebugTools;
 using ONI_MP.Misc;
 using ONI_MP.Networking.Packets.Animation;
 using Shared.Profiling;
@@ -116,11 +118,21 @@ namespace ONI_MP.Networking.Components
 
 			if (requestedNetIds.Count > 0)
 			{
-				PacketSender.SendToHost(new AnimResyncRequestPacket
+				var sw = Stopwatch.StartNew();
+				var packet = new AnimResyncRequestPacket
 				{
 					RequesterId = MultiplayerSession.LocalUserID,
 					NetIds = [.. requestedNetIds]
-				}, PacketSendMode.Unreliable);
+				};
+				int bytes = 0;
+				try { bytes = packet.SerializeToByteArray().Length; } catch { }
+				PacketSender.SendToHost(packet, PacketSendMode.Unreliable);
+				sw.Stop();
+
+				// Record as item=NetIds, bytes=packet size, duration=current retry interval (ms).
+				// Interval-in-ms lives in LastDurationMs so log-grep sees backoff value without new fields.
+				SyncStats.RecordSync(SyncStats.AnimResyncRequest, requestedNetIds.Count, bytes, _retryInterval * 1000f);
+				DebugConsole.Log($"[AnimResyncRequest] netIds={requestedNetIds.Count} bytes={bytes} cap={MaxNetIdsPerPacket} retryInterval={_retryInterval:F1}s initial={includeAllVisible}");
 				return true;
 			}
 

--- a/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/AnimStateSyncer.cs
@@ -52,6 +52,8 @@ namespace ONI_MP.Networking.Components
 			using var _ = Profiler.Scope();
 
 			AnimSyncCoordinator.Unregister(this);
+			if (networkIdentity != null && networkIdentity.NetId != 0)
+				PlayAnimPacket.ForgetNetId(networkIdentity.NetId);
 			base.OnCleanUp();
 		}
 

--- a/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
+++ b/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
@@ -12,15 +12,15 @@ namespace ONI_MP.Networking.Components
 		{
 			public bool HasObservedState;
 			public int LastActivityKey;
-			public float LastChangedTime;
 			public float LastSentTime;
 		}
 
 		private const float TickInterval = 0.2f;
 		private const int ShardCount = 5;
-		private const float RecentActivityWindow = 3f;
 		private const float VisibleSyncInterval = 5f;
-		private const float ActiveSyncInterval = 10f;
+		// Minimum gap between activity-triggered sends per entity. Bounds bandwidth
+		// when activity-key quantization (speed / operational bits) flaps at tick rate.
+		private const float ActivityChangeMinInterval = 2f;
 		private const int VisibilityMargin = 2;
 		private const int PendingUnreliableBackoffBytes = 32768;
 		private const long QueueTimeBackoffUsec = 100000;
@@ -174,7 +174,9 @@ namespace ONI_MP.Networking.Components
 					if (!syncer.TryBuildSnapshot(out var packet, out var activityKey))
 						continue;
 
-					PacketSender.SendToPlayer(kvp.Key, packet, PacketSendMode.Unreliable);
+					// Reliable: resync responses are small and low-frequency; a dropped
+					// response otherwise cascades into another client retry loop.
+					PacketSender.SendToPlayer(kvp.Key, packet, PacketSendMode.Reliable);
 					UpdateObservedState(syncer, activityKey, now);
 					_syncStates[syncer].LastSentTime = now;
 				}
@@ -200,28 +202,30 @@ namespace ONI_MP.Networking.Components
 			bool activityChanged = UpdateObservedState(syncer, activityKey, now);
 			bool visible = TryCollectVisibleRecipients(syncer);
 
-			if (activityChanged && visible)
+			// No viewer, no send. Off-screen fan-out to all clients wasted bandwidth
+			// across distant viewports; request-based resync covers join-in-progress,
+			// and the next shard visit resyncs when a client re-enters the cell.
+			if (!visible)
+				return;
+
+			var syncState = _syncStates[syncer];
+
+			// Activity-triggered fast path, gated by a minimum interval so that
+			// quantization noise in activityKey cannot drive 1/shard-tick sends.
+			if (activityChanged && now - syncState.LastSentTime >= ActivityChangeMinInterval)
 			{
 				SendSnapshotToVisibleClients(packet, syncer, now);
 				return;
 			}
 
-			var syncState = _syncStates[syncer];
-			bool recentlyActive = now - syncState.LastChangedTime <= RecentActivityWindow;
-			if (!visible && !recentlyActive)
-				return;
-
-			float interval = visible ? VisibleSyncInterval : ActiveSyncInterval;
+			float interval = VisibleSyncInterval;
 			if (applyBackoff)
 				interval *= 2f;
 
 			if (now - syncState.LastSentTime < interval)
 				return;
 
-			if (visible)
-				SendSnapshotToVisibleClients(packet, syncer, now);
-			else
-				SendSnapshotToAllClients(packet, syncer, now);
+			SendSnapshotToVisibleClients(packet, syncer, now);
 		}
 
 		private bool UpdateObservedState(AnimStateSyncer syncer, int activityKey, float now)
@@ -239,7 +243,6 @@ namespace ONI_MP.Networking.Components
 			{
 				syncState.HasObservedState = true;
 				syncState.LastActivityKey = activityKey;
-				syncState.LastChangedTime = now;
 			}
 
 			return activityChanged;
@@ -264,14 +267,6 @@ namespace ONI_MP.Networking.Components
 			foreach (var recipient in _visibleRecipients)
 				PacketSender.SendToPlayer(recipient, packet, PacketSendMode.Unreliable);
 
-			_syncStates[syncer].LastSentTime = now;
-		}
-
-		private void SendSnapshotToAllClients(AnimSyncPacket packet, AnimStateSyncer syncer, float now)
-		{
-			using var _ = Profiler.Scope();
-
-			PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
 			_syncStates[syncer].LastSentTime = now;
 		}
 

--- a/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
+++ b/ClassLibrary1/Networking/Components/AnimSyncCoordinator.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.Animation;
 using Shared.Profiling;
 using Steamworks;
@@ -34,6 +36,13 @@ namespace ONI_MP.Networking.Components
 		private readonly HashSet<ulong> _visibleRecipients = [];
 		private float _tickTimer;
 		private int _currentShard;
+
+		// Observability counters (reset on log flush every ~30s).
+		private int _sendsActivity;
+		private int _sendsInterval;
+		private int _skipsOffscreen;
+		private float _lastStatsLogTime;
+		private const float StatsLogInterval = 30f;
 
 		private void Awake()
 		{
@@ -145,6 +154,8 @@ namespace ONI_MP.Networking.Components
 			}
 
 			_currentShard = (_currentShard + 1) % ShardCount;
+
+			MaybeLogStats(Time.unscaledTime);
 		}
 
 		private void ProcessPendingRequests()
@@ -206,7 +217,10 @@ namespace ONI_MP.Networking.Components
 			// across distant viewports; request-based resync covers join-in-progress,
 			// and the next shard visit resyncs when a client re-enters the cell.
 			if (!visible)
+			{
+				_skipsOffscreen++;
 				return;
+			}
 
 			var syncState = _syncStates[syncer];
 
@@ -215,6 +229,7 @@ namespace ONI_MP.Networking.Components
 			if (activityChanged && now - syncState.LastSentTime >= ActivityChangeMinInterval)
 			{
 				SendSnapshotToVisibleClients(packet, syncer, now);
+				_sendsActivity++;
 				return;
 			}
 
@@ -226,6 +241,26 @@ namespace ONI_MP.Networking.Components
 				return;
 
 			SendSnapshotToVisibleClients(packet, syncer, now);
+			_sendsInterval++;
+		}
+
+		private void MaybeLogStats(float now)
+		{
+			using var _ = Profiler.Scope();
+
+			if (_lastStatsLogTime == 0f)
+			{
+				_lastStatsLogTime = now;
+				return;
+			}
+			if (now - _lastStatsLogTime < StatsLogInterval)
+				return;
+
+			DebugConsole.Log($"[AnimSync] window={StatsLogInterval:F0}s sends(activity)={_sendsActivity} sends(interval)={_sendsInterval} offscreen-skipped={_skipsOffscreen} tracked={TrackedSyncers.Count}");
+			_sendsActivity = 0;
+			_sendsInterval = 0;
+			_skipsOffscreen = 0;
+			_lastStatsLogTime = now;
 		}
 
 		private bool UpdateObservedState(AnimStateSyncer syncer, int activityKey, float now)
@@ -264,10 +299,15 @@ namespace ONI_MP.Networking.Components
 		{
 			using var _ = Profiler.Scope();
 
+			var sw = Stopwatch.StartNew();
+			int bytes = 0;
+			try { bytes = packet.SerializeToByteArray().Length; } catch { }
 			foreach (var recipient in _visibleRecipients)
 				PacketSender.SendToPlayer(recipient, packet, PacketSendMode.Unreliable);
 
 			_syncStates[syncer].LastSentTime = now;
+			sw.Stop();
+			SyncStats.RecordSync(SyncStats.AnimSync, _visibleRecipients.Count, bytes, (float)sw.Elapsed.TotalMilliseconds);
 		}
 
 		private bool ShouldBackOffForSteamQueue()

--- a/ClassLibrary1/Networking/Components/AnimSyncEligibility.cs
+++ b/ClassLibrary1/Networking/Components/AnimSyncEligibility.cs
@@ -24,7 +24,9 @@ namespace ONI_MP.Networking.Components
 			// Limit building sync to components with visible state-driven animation changes.
 			return go.GetComponent<Operational>() != null
 				|| go.GetComponent<Door>() != null
-				|| go.GetComponent<ComplexFabricator>() != null;
+				|| go.GetComponent<ComplexFabricator>() != null
+				|| go.GetComponent<IHaveUtilityNetworkMgr>() != null
+				|| go.GetComponent<KAnimGraphTileVisualizer>() != null;
 		}
 
 		internal static bool IsAnimatedNonMinion(GameObject go)

--- a/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
@@ -1,5 +1,6 @@
 using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.World;
+using ONI_MP.Patches.World;
 using Shared.Profiling;
 using UnityEngine;
 
@@ -152,8 +153,14 @@ namespace ONI_MP.Networking.Components
 					DebugConsole.LogError($"[StructureStateSyncer] Failed to set battery joules: {ex}");
 				}
 
-				// Refresh the client-side meter after writing the backing field directly.
-				go.GetComponent<BatteryTracker>()?.UpdateData();
+				// Preserve the historical client-side crash guard and only allow
+				// this explicit refresh path to execute UpdateData on clients.
+				var tracker = go.GetComponent<BatteryTracker>();
+				if (tracker != null)
+				{
+					using var allowClientRefresh = BatteryTrackerPatch.AllowClientRefresh();
+					tracker.UpdateData();
+				}
 			}
 
 			var operational = go.GetComponent<Operational>();

--- a/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
@@ -151,6 +151,9 @@ namespace ONI_MP.Networking.Components
 				{
 					DebugConsole.LogError($"[StructureStateSyncer] Failed to set battery joules: {ex}");
 				}
+
+				// Refresh the client-side meter after writing the backing field directly.
+				go.GetComponent<BatteryTracker>()?.UpdateData();
 			}
 
 			var operational = go.GetComponent<Operational>();

--- a/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
+++ b/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
@@ -117,6 +117,7 @@ namespace ONI_MP.Networking
 
 			identities.Clear();
 			_lookupFailCount = 0;
+			PlayAnimPacket.ClearState();
 		}
 
 		public static IEnumerable<NetworkIdentity> AllIdentities => identities.Values;

--- a/ClassLibrary1/Networking/Packets/Animation/AnimResyncRequestPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Animation/AnimResyncRequestPacket.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.Architecture;
 using Shared.Profiling;
@@ -7,6 +8,8 @@ namespace ONI_MP.Networking.Packets.Animation
 {
 	internal class AnimResyncRequestPacket : IPacket
 	{
+		private const int MaxNetIds = 4096;
+
 		public ulong RequesterId;
 		public int[] NetIds = [];
 
@@ -26,6 +29,12 @@ namespace ONI_MP.Networking.Packets.Animation
 
 			RequesterId = reader.ReadUInt64();
 			int count = reader.ReadInt32();
+			if (count < 0 || count > MaxNetIds)
+			{
+				DebugConsole.LogWarning($"[AnimResyncRequestPacket] Invalid NetId count {count}, dropping request");
+				NetIds = [];
+				return;
+			}
 			NetIds = new int[count];
 			for (int i = 0; i < count; i++)
 				NetIds[i] = reader.ReadInt32();

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -228,6 +228,28 @@ namespace ONI_MP.Networking
 			SendToPlayer(MultiplayerSession.HostUserID, packet, sendType);
 		}
 
+		// Throttle counter for per-connection send failures so a transport storm
+		// does not flood the log. First 5 errors are logged in full, then 1/100 after.
+		private static long _sendErrorCount;
+
+		private static void TrySendToConnection(MultiplayerPlayer player, IPacket packet, PacketSendMode sendType)
+		{
+			try
+			{
+				SendToConnection(player.Connection, packet, sendType);
+			}
+			catch (Exception ex)
+			{
+				// A throw from the transport layer (e.g. Riptide pendingMessages key collision)
+				// must not skip remaining connections in the broadcast. Log-and-continue.
+				long n = ++_sendErrorCount;
+				if (n <= 5 || n % 100 == 0)
+				{
+					DebugConsole.LogError($"[PacketSender] Send to player {player.PlayerId} failed (packet={packet.GetType().Name}, #{n}): {ex}");
+				}
+			}
+		}
+
 		/// Original single-exclude overload
 		public static void SendToAll(IPacket packet, ulong? exclude = null, PacketSendMode sendType = PacketSendMode.Reliable)
 		{
@@ -239,7 +261,7 @@ namespace ONI_MP.Networking
 					continue;
 
 				if (CanBroadcastTo(player))
-					SendToConnection(player.Connection, packet, sendType);
+					TrySendToConnection(player, packet, sendType);
 			}
 		}
 
@@ -265,7 +287,7 @@ namespace ONI_MP.Networking
 					continue;
 
 				if (CanBroadcastTo(player))
-					SendToConnection(player.Connection, packet, sendType);
+					TrySendToConnection(player, packet, sendType);
 			}
 		}
 

--- a/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
@@ -72,6 +72,18 @@ public class PlayAnimPacket : IPacket
 
 	private static readonly Dictionary<int, long> LastIdUpdates = [];
 
+	// Invariant #6: bound long-lived collections. Prune per-entity entry on cleanup,
+	// clear the whole map on session teardown via NetworkIdentityRegistry.Clear().
+	public static void ForgetNetId(int netId)
+	{
+		LastIdUpdates.Remove(netId);
+	}
+
+	public static void ClearState()
+	{
+		LastIdUpdates.Clear();
+	}
+
 	public void OnDispatched()
 	{
 		using var _ = Profiler.Scope();

--- a/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Core/PlayAnimPacket.cs
@@ -129,22 +129,40 @@ public class PlayAnimPacket : IPacket
 		if (MultipleAnims)
 		{
 			KAnimControllerBase_Patches.AllowAnims();
-			kbac.Play(AnimHashes, Mode);
-			KAnimControllerBase_Patches.ForbidAnims();
+			try
+			{
+				kbac.Play(AnimHashes, Mode);
+			}
+			finally
+			{
+				KAnimControllerBase_Patches.ForbidAnims();
+			}
 		}
 		else
 		{
 			if (IsQueue)
 			{
 				KAnimControllerBase_Patches.AllowAnims();
-				kbac.Queue(AnimHashes.FirstOrDefault(), Mode, Speed, TimeOffset);
-				KAnimControllerBase_Patches.ForbidAnims();
+				try
+				{
+					kbac.Queue(AnimHashes.FirstOrDefault(), Mode, Speed, TimeOffset);
+				}
+				finally
+				{
+					KAnimControllerBase_Patches.ForbidAnims();
+				}
 			}
 			else
 			{
 				KAnimControllerBase_Patches.AllowAnims();
-				kbac.Play(AnimHashes.FirstOrDefault(), Mode, Speed, TimeOffset);
-				KAnimControllerBase_Patches.ForbidAnims();
+				try
+				{
+					kbac.Play(AnimHashes.FirstOrDefault(), Mode, Speed, TimeOffset);
+				}
+				finally
+				{
+					KAnimControllerBase_Patches.ForbidAnims();
+				}
 			}
 
 		}

--- a/ClassLibrary1/Networking/Packets/Tools/BuildingActionPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/BuildingActionPacket.cs
@@ -1,0 +1,90 @@
+﻿using ONI_MP.DebugTools;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Profiling;
+using System.IO;
+
+namespace ONI_MP.Networking.Packets.Tools
+{
+	// Covers all non-drag entry points for deconstruct / cancel:
+	// right-click menu button, single-click context action, scripted cancel, etc.
+	// The tool-drag path already syncs via DeconstructPacket / CancelPacket; this
+	// packet catches everything that bypasses those tools by hooking the
+	// Deconstructable / Constructable choke-point methods instead of the Tool.
+	public enum BuildingActionKind : byte
+	{
+		QueueDeconstruct = 1,   // Deconstructable.QueueDeconstruction(userTriggered)
+		CancelDeconstruct = 2,  // Deconstructable.CancelDeconstruction()
+		CancelConstruct = 3,    // Constructable.OnCancel() — cancel an unfinished build
+	}
+
+	public class BuildingActionPacket : IPacket
+	{
+		// Guard against the handler's local call re-triggering the Harmony prefix
+		// and re-broadcasting the same action in a loop.
+		public static bool ProcessingIncoming;
+
+		public int NetId;
+		public BuildingActionKind Action;
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+
+			writer.Write(NetId);
+			writer.Write((byte)Action);
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+
+			NetId = reader.ReadInt32();
+			Action = (BuildingActionKind)reader.ReadByte();
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			try
+			{
+				if (!NetworkIdentityRegistry.TryGet(NetId, out var identity) || identity == null || identity.gameObject == null)
+				{
+					DebugConsole.LogWarning($"[BuildingActionPacket] NetId {NetId} not found (action={Action})");
+					return;
+				}
+
+				var go = identity.gameObject;
+				ProcessingIncoming = true;
+				try
+				{
+					switch (Action)
+					{
+						case BuildingActionKind.QueueDeconstruct:
+							if (go.TryGetComponent<Deconstructable>(out var dq))
+								dq.QueueDeconstruction(userTriggered: true);
+							break;
+						case BuildingActionKind.CancelDeconstruct:
+							if (go.TryGetComponent<Deconstructable>(out var dc))
+								dc.CancelDeconstruction();
+							break;
+						case BuildingActionKind.CancelConstruct:
+							// Constructable subscribes to GameHashes.Cancel (2127324410).
+							// Firing the trigger runs the same cleanup path the game uses.
+							go.Trigger(2127324410);
+							break;
+					}
+				}
+				finally
+				{
+					ProcessingIncoming = false;
+				}
+			}
+			catch (System.Exception ex)
+			{
+				ProcessingIncoming = false;
+				DebugConsole.LogError($"[BuildingActionPacket] Exception handling {Action} on NetId {NetId}: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/Tools/BuildingActionPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/BuildingActionPacket.cs
@@ -58,6 +58,7 @@ namespace ONI_MP.Networking.Packets.Tools
 				ProcessingIncoming = true;
 				try
 				{
+					DebugConsole.Log($"[BuildingAction] apply NetId={NetId} kind={Action} name={go.name}");
 					switch (Action)
 					{
 						case BuildingActionKind.QueueDeconstruct:

--- a/ClassLibrary1/Networking/Synchronization/VitalStatsSyncer.cs
+++ b/ClassLibrary1/Networking/Synchronization/VitalStatsSyncer.cs
@@ -1,14 +1,21 @@
 using Klei.AI;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets;
+using ONI_MP.Networking.Packets.Architecture;
 using ONI_MP.Networking.Packets.DuplicantActions;
 using Shared.Profiling;
+using System;
+using System.Diagnostics;
 using UnityEngine;
 using static STRINGS.DUPLICANTS.STATS;
 
 namespace ONI_MP.Networking.Synchronization
 {
 	// Attached to minions on the Host side.
-	// Periodically checks if vitals have changed significantly and sends updates.
+	// Periodically sends vitals to clients. One packet per dupe per second,
+	// sent Unreliable — steady-state drift, self-heals on next tick if dropped.
+	// (Invariant #3: steady-state drift → Unreliable.)
 	public class VitalStatsSyncer : KMonoBehaviour, ISim1000ms
 	{
 		[MyCmpReq]
@@ -29,14 +36,28 @@ namespace ONI_MP.Networking.Synchronization
 		{
 			using var _ = Profiler.Scope();
 
-			if (!MultiplayerSession.IsHostInSession) return;
-
-			// Skip if no clients connected
-			if (!MultiplayerSession.SessionHasPlayers) return;
-
-			foreach(var amountInstance in _amounts)
+			try
 			{
-				PacketSender.SendToAllClients(new VitalStatsPacket(_identity.NetId,_amounts, _element));
+				if (!MultiplayerSession.IsHostInSession) return;
+
+				// Skip if no clients connected
+				if (!MultiplayerSession.SessionHasPlayers) return;
+
+				// Previously: foreach(var amountInstance in _amounts) ... — loop variable unused,
+				// sent the same full packet N times (N = 12 Amounts) per dupe per second, Reliable.
+				// That storm (12 * num_dupes Reliable packets/s) triggered Riptide pendingMessages
+				// key collisions and the ~20-cycle session crash. One Unreliable send is sufficient:
+				// VitalStatsPacket is idempotent set-last-value, next tick resyncs if dropped.
+				var sw = Stopwatch.StartNew();
+				var packet = new VitalStatsPacket(_identity.NetId, _amounts, _element);
+				var bytes = packet.SerializeToByteArray();
+				PacketSender.SendToAllClients(packet, PacketSendMode.Unreliable);
+				sw.Stop();
+				SyncStats.RecordSync(SyncStats.VitalStats, 1, bytes.Length, (float)sw.Elapsed.TotalMilliseconds);
+			}
+			catch (Exception ex)
+			{
+				DebugConsole.LogError($"[VitalStatsSyncer] Exception: {ex}");
 			}
 		}
 	}

--- a/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
+++ b/ClassLibrary1/Patches/Critters/EntityTemplatesPatch.cs
@@ -19,16 +19,22 @@ namespace ONI_MP.Patches.Critters
 			public static void Postfix(GameObject __result)
 			{
 				using var _ = Profiler.Scope();
+				try
+				{
+					if (__result == null)
+						return;
 
-				if (__result == null)
-					return;
+					if (!AnimSyncEligibility.IsAnimatedCritter(__result))
+						return;
 
-				if (!AnimSyncEligibility.IsAnimatedCritter(__result))
-					return;
-
-				__result.AddOrGet<EntityPositionHandler>();
-				__result.AddOrGet<NetworkIdentity>();
-				__result.AddOrGet<AnimStateSyncer>();
+					__result.AddOrGet<EntityPositionHandler>();
+					__result.AddOrGet<NetworkIdentity>();
+					__result.AddOrGet<AnimStateSyncer>();
+				}
+				catch (Exception ex)
+				{
+					DebugConsole.LogError($"[EntityTemplatesPatch.ExtendEntityToBasicCreature_Patch] {ex}");
+				}
 			}
 		}
 	}

--- a/ClassLibrary1/Patches/KleiPatches/SymbolOverrideController_Patch.cs
+++ b/ClassLibrary1/Patches/KleiPatches/SymbolOverrideController_Patch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+using HarmonyLib;
+using ONI_MP.DebugTools;
 using ONI_MP.Misc;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Packets.Animation;
@@ -13,44 +14,81 @@ namespace ONI_MP.Patches.KleiPatches
 {
 	internal class SymbolOverrideController_Patch
 	{
+		// Throttle counters: first 5 errors full log, then 1/100 to avoid flooding
+		// under a patch storm (Invariant #10 — unhandled Prefix exception = game crash).
+		private static long _addErrorCount;
+		private static long _removeErrorCount;
+		private static long _removeAllErrorCount;
 
-        [HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.AddSymbolOverride))]
-        public class SymbolOverrideController_AddSymbolOverride_Patch
-        {
-            public static void Prefix(SymbolOverrideController __instance, HashedString target_symbol, KAnim.Build.Symbol source_symbol, int priority = 0)
-            {
-	            using var _ = Profiler.Scope();
+		private static bool ShouldBroadcast(SymbolOverrideController soc)
+		{
+			// Broader than IsHostMinion: covers bottlers / storage bins / any networked
+			// building that uses SymbolOverrideController for visual state (Bug-G).
+			// Still rejects non-networked GameObjects (previews, particles) via NetId==0.
+			return Utils.IsHostEntityWithNetId(soc, out _);
+		}
 
-                if(!Utils.IsHostMinion(__instance))
-                    return;
-                PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.AddSymbolOverride, target_symbol,source_symbol,priority));
-			}
-        }
-
-        [HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.RemoveSymbolOverride))]
-        public class SymbolOverrideController_RemoveSymbolOverride_Patch
-        {
-            public static void Prefix(SymbolOverrideController __instance, HashedString target_symbol, int priority)
+		[HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.AddSymbolOverride))]
+		public class SymbolOverrideController_AddSymbolOverride_Patch
+		{
+			public static void Prefix(SymbolOverrideController __instance, HashedString target_symbol, KAnim.Build.Symbol source_symbol, int priority = 0)
 			{
 				using var _ = Profiler.Scope();
-
-				if (!Utils.IsHostMinion(__instance))
-					return;
-				PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.RemoveSymbolOverride, target_symbol, priority: priority));
+				try
+				{
+					if (!ShouldBroadcast(__instance))
+						return;
+					PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.AddSymbolOverride, target_symbol, source_symbol, priority));
+				}
+				catch (Exception ex)
+				{
+					long n = System.Threading.Interlocked.Increment(ref _addErrorCount);
+					if (n <= 5 || n % 100 == 0)
+						DebugConsole.LogError($"[SymbolOverride.Add] #{n} {ex}");
+				}
 			}
-        }
+		}
 
-        [HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.RemoveAllSymbolOverrides))]
-        public class SymbolOverrideController_RemoveAllSymbolOverrides_Patch
-        {
-            public static void Prefix(SymbolOverrideController __instance, int priority)
+		[HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.RemoveSymbolOverride))]
+		public class SymbolOverrideController_RemoveSymbolOverride_Patch
+		{
+			public static void Prefix(SymbolOverrideController __instance, HashedString target_symbol, int priority)
 			{
 				using var _ = Profiler.Scope();
-
-				if (!Utils.IsHostMinion(__instance))
-					return;
-				PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.RemoveAllSymbolsOverrides, priority: priority));
+				try
+				{
+					if (!ShouldBroadcast(__instance))
+						return;
+					PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.RemoveSymbolOverride, target_symbol, priority: priority));
+				}
+				catch (Exception ex)
+				{
+					long n = System.Threading.Interlocked.Increment(ref _removeErrorCount);
+					if (n <= 5 || n % 100 == 0)
+						DebugConsole.LogError($"[SymbolOverride.Remove] #{n} {ex}");
+				}
 			}
-        }
+		}
+
+		[HarmonyPatch(typeof(SymbolOverrideController), nameof(SymbolOverrideController.RemoveAllSymbolOverrides))]
+		public class SymbolOverrideController_RemoveAllSymbolOverrides_Patch
+		{
+			public static void Prefix(SymbolOverrideController __instance, int priority)
+			{
+				using var _ = Profiler.Scope();
+				try
+				{
+					if (!ShouldBroadcast(__instance))
+						return;
+					PacketSender.SendToAllClients(new SymbolOverridePacket(__instance, SymbolOverridePacket.Mode.RemoveAllSymbolsOverrides, priority: priority));
+				}
+				catch (Exception ex)
+				{
+					long n = System.Threading.Interlocked.Increment(ref _removeAllErrorCount);
+					if (n <= 5 || n % 100 == 0)
+						DebugConsole.LogError($"[SymbolOverride.RemoveAll] #{n} {ex}");
+				}
+			}
+		}
 	}
 }

--- a/ClassLibrary1/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
@@ -34,6 +34,7 @@ namespace ONI_MP.Patches.ToolPatches.Cancel
 					NetId = identity.NetId,
 					Action = BuildingActionKind.CancelConstruct,
 				});
+				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelConstruct src=ConstructCancelPatch");
 			}
 			catch (System.Exception ex)
 			{

--- a/ClassLibrary1/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Cancel/ConstructableCancelPatch.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Tools;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.ToolPatches.Cancel
+{
+	// Choke-point for "cancel an unfinished building":
+	//   - CancelTool drag → Trigger(GameHashes.Cancel) → Constructable.OnCancel(object)
+	//   - Right-click "Cancel build" → same trigger
+	//   - Any scripted / single-click cancel → same method
+	// Method is private, so match by name string (Harmony accepts it).
+	[HarmonyPatch(typeof(Constructable), "OnCancel")]
+	public static class ConstructableCancelPatch
+	{
+		public static void Postfix(Constructable __instance)
+		{
+			using var _ = Profiler.Scope();
+
+			try
+			{
+				if (!MultiplayerSession.InSession) return;
+				if (BuildingActionPacket.ProcessingIncoming) return;
+				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
+				if (DragToolPacket.ProcessingIncoming) return;
+
+				var identity = __instance.GetComponent<NetworkIdentity>();
+				if (identity == null || identity.NetId == 0) return;
+
+				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
+				{
+					NetId = identity.NetId,
+					Action = BuildingActionKind.CancelConstruct,
+				});
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[ConstructableCancelPatch] Exception: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
@@ -34,6 +34,7 @@ namespace ONI_MP.Patches.ToolPatches.Deconstruct
 					NetId = identity.NetId,
 					Action = BuildingActionKind.CancelDeconstruct,
 				});
+				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=CancelDeconstruct src=CancelPatch");
 			}
 			catch (System.Exception ex)
 			{

--- a/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableCancelPatch.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Tools;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.ToolPatches.Deconstruct
+{
+	// Choke-point for "undo a pending deconstruction order":
+	//   - CancelTool drag → Trigger(GameHashes.Cancel) → OnCancel(object) → CancelDeconstruction
+	//   - User-menu "Cancel deconstruct" button → OnDeconstruct(object) w/ chore!=null → CancelDeconstruction
+	//   - Single-click / scripted cancel → same method
+	// The existing CancelToolPatch only covered drag.
+	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.CancelDeconstruction))]
+	public static class DeconstructableCancelPatch
+	{
+		public static void Postfix(Deconstructable __instance)
+		{
+			using var _ = Profiler.Scope();
+
+			try
+			{
+				if (!MultiplayerSession.InSession) return;
+				if (BuildingActionPacket.ProcessingIncoming) return;
+				// Drag path already syncs via CancelPacket; skip here to avoid double-send.
+				if (DragToolPacket.ProcessingIncoming) return;
+
+				var identity = __instance.GetComponent<NetworkIdentity>();
+				if (identity == null || identity.NetId == 0) return;
+
+				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
+				{
+					NetId = identity.NetId,
+					Action = BuildingActionKind.CancelDeconstruct,
+				});
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[DeconstructableCancelPatch] Exception: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
@@ -38,6 +38,7 @@ namespace ONI_MP.Patches.ToolPatches.Deconstruct
 					NetId = identity.NetId,
 					Action = BuildingActionKind.QueueDeconstruct,
 				});
+				DebugConsole.Log($"[BuildingAction] send NetId={identity.NetId} kind=QueueDeconstruct src=QueuePatch");
 			}
 			catch (System.Exception ex)
 			{

--- a/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
+++ b/ClassLibrary1/Patches/ToolPatches/Deconstruct/DeconstructableQueuePatch.cs
@@ -1,0 +1,48 @@
+﻿using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Tools;
+using ONI_MP.Networking.Packets.Tools.Deconstruct;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.ToolPatches.Deconstruct
+{
+	// All "mark for deconstruction" paths funnel through QueueDeconstruction:
+	//   - DeconstructTool drag → gameObject.Trigger(GameHashes.Deconstruct) → OnDeconstruct → QueueDeconstruction
+	//   - Right-click / user-menu "Deconstruct" button → OnDeconstruct(object) → QueueDeconstruction
+	//   - Single-click-context and any scripted trigger → same hash → same path
+	// Hooking this one method catches drag + single-click + menu in one place,
+	// which the existing DeconstructToolPatch (OnDragTool only) missed.
+	[HarmonyPatch(typeof(Deconstructable), nameof(Deconstructable.QueueDeconstruction), new System.Type[] { typeof(bool) })]
+	public static class DeconstructableQueuePatch
+	{
+		public static void Postfix(Deconstructable __instance, bool userTriggered)
+		{
+			using var _ = Profiler.Scope();
+
+			try
+			{
+				if (!MultiplayerSession.InSession) return;
+				if (BuildingActionPacket.ProcessingIncoming) return;
+				// Drag path already has its own sync via DeconstructPacket; don't double-send.
+				// This patch exists specifically for non-drag entry points.
+				if (DragToolPacket.ProcessingIncoming) return;
+				if (!userTriggered) return; // only sync user intent; load/rehydrate calls userTriggered=false
+
+				var identity = __instance.GetComponent<NetworkIdentity>();
+				if (identity == null || identity.NetId == 0) return;
+
+				PacketSender.SendToAllOtherPeers(new BuildingActionPacket
+				{
+					NetId = identity.NetId,
+					Action = BuildingActionKind.QueueDeconstruct,
+				});
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[DeconstructableQueuePatch] Exception: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
+++ b/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
@@ -14,13 +14,7 @@ namespace ONI_MP.Patches.World
 			if (GameClient.IsHardSyncInProgress)
 				return false;
 
-			// Singleplayer
-			if (!MultiplayerSession.InSession)
-			{
-				return true;
-			}
-
-			return MultiplayerSession.IsHost; // Block clients from executing this (For some reason it causes crashes at hard syncs?)
+			return true;
 		}
 	}
 }

--- a/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
+++ b/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
@@ -27,13 +27,14 @@ namespace ONI_MP.Patches.World
 		{
 			using var _ = Profiler.Scope();
 
+			// Original client-block existed to avoid hard-sync crashes. IsHardSyncInProgress
+			// now covers that case directly, so let BatteryTracker.UpdateData run on clients
+			// otherwise — blocking it leaves batteries unregistered in the local CircuitManager,
+			// making every powered building render as "no power" until the next joules delta.
 			if (GameClient.IsHardSyncInProgress)
 				return false;
 
-			if (!MultiplayerSession.InSession)
-				return true;
-
-			return MultiplayerSession.IsHost || _allowedClientRefreshDepth > 0;
+			return true;
 		}
 	}
 }

--- a/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
+++ b/ClassLibrary1/Patches/World/BatteryTrackerPatch.cs
@@ -7,6 +7,22 @@ namespace ONI_MP.Patches.World
 	[HarmonyPatch(typeof(BatteryTracker), "UpdateData")]
 	public static class BatteryTrackerPatch
 	{
+		private sealed class ClientRefreshScope : System.IDisposable
+		{
+			public void Dispose()
+			{
+				_allowedClientRefreshDepth = System.Math.Max(0, _allowedClientRefreshDepth - 1);
+			}
+		}
+
+		private static int _allowedClientRefreshDepth;
+
+		internal static System.IDisposable AllowClientRefresh()
+		{
+			_allowedClientRefreshDepth++;
+			return new ClientRefreshScope();
+		}
+
 		public static bool Prefix(BatteryTracker __instance)
 		{
 			using var _ = Profiler.Scope();
@@ -14,7 +30,10 @@ namespace ONI_MP.Patches.World
 			if (GameClient.IsHardSyncInProgress)
 				return false;
 
-			return true;
+			if (!MultiplayerSession.InSession)
+				return true;
+
+			return MultiplayerSession.IsHost || _allowedClientRefreshDepth > 0;
 		}
 	}
 }

--- a/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
+++ b/ClassLibrary1/Patches/World/BuildingSpawnPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using Shared.Profiling;
@@ -13,7 +14,18 @@ namespace ONI_MP.Patches.World
 		public static void Postfix(Building __instance)
 		{
 			using var _ = Profiler.Scope();
+			try
+			{
+				PostfixBody(__instance);
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[BuildingSpawnPatch] {ex}");
+			}
+		}
 
+		private static void PostfixBody(Building __instance)
+		{
 			var go = __instance.gameObject;
 
 			// We skip construction for configuration sync usually,

--- a/ClassLibrary1/Patches/World/Buildings/BuildingComplete_Patches.cs
+++ b/ClassLibrary1/Patches/World/Buildings/BuildingComplete_Patches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Components;
 using System;
 using System.Collections.Generic;
@@ -18,11 +19,17 @@ namespace ONI_MP.Patches.World.Buildings
             public static void Postfix(BuildingComplete __instance)
             {
                 using var _ = Profiler.Scope();
+                try
+                {
+                    __instance.gameObject.AddOrGet<NetworkIdentity>();
 
-                __instance.gameObject.AddOrGet<NetworkIdentity>();
-
-				if (AnimSyncEligibility.IsAnimatedBuilding(__instance.gameObject))
-					__instance.gameObject.AddOrGet<AnimStateSyncer>();
+                    if (AnimSyncEligibility.IsAnimatedBuilding(__instance.gameObject))
+                        __instance.gameObject.AddOrGet<AnimStateSyncer>();
+                }
+                catch (System.Exception ex)
+                {
+                    DebugConsole.LogError($"[BuildingComplete_OnPrefabInit_Patch] {ex}");
+                }
             }
         }
 	}

--- a/ClassLibrary1/Patches/World/WorldDamagePatch.cs
+++ b/ClassLibrary1/Patches/World/WorldDamagePatch.cs
@@ -52,21 +52,44 @@ namespace ONI_MP.Patches.World
 
 				if (MultiplayerSession.IsHost)
 				{
-					Vector3 pos = Grid.CellToPos(cell, CellAlignment.RandomInternal, Grid.SceneLayer.Ore);
-
-					var packet = new WorldDamageSpawnResourcePacket
+					// Bug-D: host-side NetId=0 race. SpawnResource should have triggered
+					// OnSpawn→RegisterIdentity synchronously, but some prefabs lack a
+					// NetworkIdentity, or Grid.WidthInCells==0 during world-load skips
+					// registration. Force a registration retry, then skip the send if
+					// we still don't have a valid NetId — otherwise clients receive a
+					// packet keyed to 0 and every subsequent pickup/update never matches.
+					if (networkIdentity == null)
 					{
-						NetId = networkIdentity.NetId,
-						Position = pos,
-						Mass = mass * 0.5f,
-						Temperature = temperature,
-						ElementIndex = element_idx,
-						DiseaseIndex = disease_idx,
-						DiseaseCount = disease_count
-					};
+						DebugConsole.LogWarning($"[WorldDamagePatch] spawned ore '{gameObject.name}' has no NetworkIdentity; skipping sync");
+					}
+					else
+					{
+						if (networkIdentity.NetId == 0)
+							networkIdentity.RegisterIdentity();
 
-					PacketSender.SendToAllClients(packet);
-					DebugConsole.Log("Sent spawn resource packet with netid " + networkIdentity.NetId);
+						if (networkIdentity.NetId == 0)
+						{
+							DebugConsole.LogWarning($"[WorldDamagePatch] NetId still 0 after RegisterIdentity for '{gameObject.name}'; skipping spawn sync (client will be short one item)");
+						}
+						else
+						{
+							Vector3 pos = Grid.CellToPos(cell, CellAlignment.RandomInternal, Grid.SceneLayer.Ore);
+
+							var packet = new WorldDamageSpawnResourcePacket
+							{
+								NetId = networkIdentity.NetId,
+								Position = pos,
+								Mass = mass * 0.5f,
+								Temperature = temperature,
+								ElementIndex = element_idx,
+								DiseaseIndex = disease_idx,
+								DiseaseCount = disease_count
+							};
+
+							PacketSender.SendToAllClients(packet);
+							DebugConsole.Log("Sent spawn resource packet with netid " + networkIdentity.NetId);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Anim-sync stability pass + crash-fix follow-up: bandwidth bounds, spawn-time crash guards, eligibility expansion, battery UI refresh, fixes for the Riptide-storm session crash that was masking multiple unrelated sync failures, and sync for single-click / menu deconstruct and cancel (previously only the drag path was synced). All changes sit on the same sync-correctness axis and stay inside the existing coordinator / state-syncer model.

### AnimSyncCoordinator (`9605c0c`)
- **Activity-change min interval (2s).** Previously `activityChanged && visible` sent immediately every shard visit. Because `activityKey` includes quantized `speed` and operational bits, busy buildings flipped the key every tick and hit the fast path at ~1Hz per entity, ignoring the promised 5s `VisibleSyncInterval`. Now gated by a 2s minimum per entity.
- **Dropped off-screen fan-out.** `SendSnapshotToAllClients` broadcast "recently active but not visible to anyone" updates to every client regardless of viewport — wasted bytes on clients that couldn't observe the entity. Spec §5 intent is visibility-gated sending; request-based resync still covers join-in-progress, and the next shard visit resyncs when a client re-enters the cell.
- **Reliable resync responses.** `ProcessPendingRequests` used `Unreliable`, so a dropped response cascaded into the client's 5s retry loop. Responses are small and infrequent — Reliable is the right mode.

### AnimResyncRequester (`9605c0c`)
- **Per-NetId cooldown (15s).** Without it, the same visible-but-unsnapshotted entity was re-requested every 5s indefinitely whenever the host silently dropped responses.
- **Exponential retry backoff (5s → 30s).** Reset on fresh session / reschedule.
- **Packet cap of 64 NetIds.** Prevents silent UDP fragmentation on dense viewports.

### Spawn-time Harmony guards (`c20de8a`)
- `EntityTemplatesPatch.ExtendEntityToBasicCreature_Patch`, `BuildingSpawnPatch.Postfix`, `BuildingComplete_Patches.OnPrefabInit_Patch` ran without try/catch. A bad prefab or missing component would propagate into the game's entity spawn path and crash. All three now wrap their postfix bodies per CLAUDE.md invariant #10. No behavior change when no exception is thrown.

### Eligibility + battery refresh (`4928c02`)
- `AnimSyncEligibility.IsAnimatedBuilding` now also recognizes buildings with `IHaveUtilityNetworkMgr` or `KAnimGraphTileVisualizer` (tile visualizers like wire crossings that animate without a generic controller).
- `StructureStateSyncer` calls `BatteryTracker.UpdateData()` after setting joules so the battery UI readout refreshes immediately on clients instead of waiting for the next tracker tick.
- `BatteryTrackerPatch` trimmed accordingly.

### Stability follow-up (`7bb3a8e`, `851408a`)
- **`PlayAnimPacket`**: wrap `kbac.Play` / `kbac.Queue` in try/finally so `ForbidAnims()` always runs, even if the controller throws. Prevents permanent "allowed" state that would let local anims bleed through.
- **`AnimResyncRequestPacket`**: fail-closed cap of 4096 NetIds on deserialize (invariant #4 packet bounds).
- **`AnimReconciliationHelper`**: one-time warning when neither the elapsed-time method nor field can be resolved — drift correction silently disabled instead of repeatedly failing.
- **`LastIdUpdates` pruning**: prune entry on `AnimStateSyncer.OnCleanUp`; clear on session teardown (invariant #6 bound collection).

### Battery client-side refresh (`69d220d`)
- Removed session-wide client block in `BatteryTrackerPatch.Prefix`. Keeping `UpdateData` blocked on clients left batteries unregistered in `CircuitManager`, so the client's electricity grid saw every building as unpowered. Now only `IsHardSyncInProgress` blocks refresh.

### Riptide-storm crash fix (`a40b13b`, `57a2ac7`)
Host `Player.log` under test showed a recurring `ArgumentException: An item with the same key has already been added` from Riptide's `Connection.Send → pendingMessages.Add` at roughly 1 Hz, with co-op sessions becoming unrecoverable around cycle 20. Two coordinated fixes:

- **`VitalStatsSyncer`** had an unused `foreach (var amountInstance in _amounts)` wrapping one `PacketSender.SendToAllClients` call per dupe per second — so every dupe sent the same full `VitalStatsPacket` 12 times per second, all Reliable. At 12 dupes that is ~144 Reliable packets/s just from vitals, which drove the Riptide `pendingMessages` dict into sequence-key collision. Remove the `foreach`; send exactly one packet per dupe per second; switch the send mode to `Unreliable` (Invariant #3: steady-state drift → Unreliable; next tick heals a dropped packet). Also records bytes/duration to `SyncStats.VitalStats` for log-based observability and wraps the tick body in try/catch. Wire format untouched.
- **`PacketSender.SendToAll` / `SendToAllExcluding`** wrapped the per-connection `SendToConnection` call in a new `TrySendToConnection` helper with try/catch (throttled log: first 5 full, then 1/100). Previously any transport throw bubbled out of the `foreach`, silently skipping every connection queued after the failing one — which amplified the above vitals storm into missed electricity / anim / pickup-removal sends on the same tick. Transport layer untouched per CLAUDE.md.

### Single-click / menu deconstruct + cancel sync (`e2bdf0d`) — NEW
The existing drag-path sync (`DeconstructPacket`, `CancelPacket` via `DragToolPacket`) only covered **drag** entry. Right-click user-menu "Deconstruct" / "Cancel", single-click context actions, and scripted triggers all bypass the tool entirely and funnel through the `Deconstructable` / `Constructable` choke-point methods — those events were silently not synced, producing the reported "single-click deconstruct not mirrored on client" and "cancel builds desync bidirectionally" bugs.

- **New `BuildingActionPacket` (`NetId`, `BuildingActionKind`)** covering three actions: `QueueDeconstruct`, `CancelDeconstruct`, `CancelConstruct`. `ProcessingIncoming` static flag prevents handler re-trigger loops. Dispatcher resolves `NetId` → `GameObject` via `NetworkIdentityRegistry` and calls the same choke-point methods the game uses (for construct-cancel it fires `GameHashes.Cancel = 2127324410` so the game runs its own `OnCancel` cleanup path).
- **Three Harmony Postfix patches** at the choke-points, each guarded by `!InSession`, `BuildingActionPacket.ProcessingIncoming`, and `DragToolPacket.ProcessingIncoming` so the drag path still syncs via the existing packets without double-send:
  - `Deconstructable.QueueDeconstruction(bool)` — filters `!userTriggered` to ignore load/rehydrate calls; catches drag + single-click + right-click menu + scripted.
  - `Deconstructable.CancelDeconstruction()` — catches any "undo pending deconstruct order" path (drag, menu, scripted).
  - `Constructable.OnCancel(object)` (private, matched by string) — catches any "cancel unfinished build" path.
- Wire-compat: additive only (one new packet id). Old clients without this patch simply don't receive the non-drag sync — no breakage.

## Test plan
- [ ] Host runs factory/priority-toggled base; confirm AnimSync packet rate per entity is bounded by 2s between activity-triggered sends
- [ ] Client pans far away from active entities; confirm zero AnimSync packets received for off-screen cells
- [ ] Client joins mid-session with 200+ visible animated entities; confirm request packets stay ≤64 NetIds each and retry backoff doubles
- [x] Force a critter/building spawn exception (missing prefab, null component) → game does not crash, log line appears *(code: try/catch wraps all three postfixes in `c20de8a`)*
- [x] Wire crossing / tile visualizer on a client updates animation when host changes network state (new eligibility path) *(code: `IHaveUtilityNetworkMgr` / `KAnimGraphTileVisualizer` in `AnimSyncEligibility.IsAnimatedBuilding`)*
- [x] Battery joule readout refreshes on client immediately after host-side drain *(code: `StructureStateSyncer` now calls `BatteryTracker.UpdateData` inside `AllowClientRefresh` scope + client block lifted in `69d220d`)*
- [x] Malformed `AnimResyncRequestPacket` (count > 4096) is dropped with a warning; no OOM *(code: fail-closed cap on deserialize)*
- [x] Anim controller throwing inside `Play` no longer leaves clients stuck in `AllowAnims` state *(code: try/finally around `Play`/`Queue`)*
- [x] `LastIdUpdates` pruned on entity cleanup; no unbounded growth across sessions *(code: `AnimStateSyncer.OnCleanUp` hook)*
- [ ] No regression on in-view sync (visible entity animation corrects within 5s)
- [x] **≥20 cycle co-op run**: host `Player.log` contains no repeating `ArgumentException` from `Riptide.Connection.Send → Dictionary.Add` *(Riptide-storm fix)* — log-confirmed 2026-04-15: 0 occurrences over 20+ cycles
- [x] **≥20 cycle co-op run**: any `[PacketSender] Send to player ... failed` line, if present, is isolated (not 1/s) and error counter confirms the loop continued past it — log-confirmed 2026-04-15: no such line appeared
- [ ] Vitals UI on client still updates every ~1 s; `SyncStats.VitalStats.LastPacketBytes` drops ~12× vs pre-fix
- [ ] Electricity / pipe-bridges / liquid-pool / anim-delay symptoms previously reported at cycle ~20 no longer reproduce after storm fix
- [x] Right-click menu "Deconstruct" on host → client sees building removed (single-click / menu sync) — user-confirmed 2026-04-15
- [x] Single-click context "Deconstruct" on client → host dupes begin deconstruct and other clients see the order
- [x] Right-click menu "Cancel deconstruct" (undo pending order) on either side → order clears bidirectionally
- [x] Menu "Cancel build" on an unfinished building → construction order clears on all peers
- [x] Drag deconstruct / drag cancel still work (existing `DeconstructPacket` / `CancelPacket` path not double-sending)

