### PR TITLE
fix: remove ground item ghosts on clients after host pickup

### DIFF
--- a/ClassLibrary1/DebugTools/UnitTests/GroundItemTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/GroundItemTests.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
+
+namespace ONI_MP.DebugTools.UnitTests
+{
+	public static class GroundItemTests
+	{
+		[UnitTest(name: "GroundItemPickedUpPacket: serialization roundtrip", category: "GroundItems")]
+		public static UnitTestResult PacketRoundtrip()
+		{
+			var original = new GroundItemPickedUpPacket { NetId = 999888777 };
+			using var ms = new MemoryStream();
+			using var writer = new BinaryWriter(ms);
+			original.Serialize(writer);
+			ms.Position = 0;
+			using var reader = new BinaryReader(ms);
+			var copy = new GroundItemPickedUpPacket();
+			copy.Deserialize(reader);
+			if (copy.NetId != original.NetId)
+				return UnitTestResult.Fail($"NetId mismatch: {copy.NetId} != {original.NetId}");
+			return UnitTestResult.Pass("GroundItemPickedUpPacket roundtrip OK");
+		}
+
+		[UnitTest(name: "GroundItemPickedUpPacket: is IBulkablePacket", category: "GroundItems")]
+		public static UnitTestResult IsBulkable()
+		{
+			var p = new GroundItemPickedUpPacket();
+			if (p.MaxPackSize != 200)
+				return UnitTestResult.Fail($"MaxPackSize expected 200, got {p.MaxPackSize}");
+			if (p.IntervalMs != 200)
+				return UnitTestResult.Fail($"IntervalMs expected 200, got {p.IntervalMs}");
+			return UnitTestResult.Pass($"GroundItemPickedUpPacket IBulkablePacket: MaxPackSize={p.MaxPackSize}, IntervalMs={p.IntervalMs}");
+		}
+
+		[UnitTest(name: "GroundItems: NetworkIdentityRegistry accessible", category: "GroundItems")]
+		public static UnitTestResult RegistryAccessible()
+		{
+			// TryGetComponent with a non-existent NetId should return false (not throw)
+			bool found = NetworkIdentityRegistry.TryGetComponent<Pickupable>(-1, out _);
+			if (found)
+				return UnitTestResult.Fail("NetId -1 should not exist in registry");
+			return UnitTestResult.Pass("NetworkIdentityRegistry.TryGetComponent accessible and returns false for unknown NetId");
+		}
+
+		[UnitTest(name: "ClearTool.Instance accessible (sweep relay)", category: "GroundItems")]
+		public static UnitTestResult ClearToolAccessible()
+		{
+			if (ClearTool.Instance == null)
+				return UnitTestResult.Fail("ClearTool.Instance is null");
+			return UnitTestResult.Pass("ClearTool.Instance accessible");
+		}
+	}
+}

--- a/ClassLibrary1/DebugTools/UnitTests/GroundItemTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/GroundItemTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using ONI_MP.Networking;
 using ONI_MP.Networking.Components;
 using ONI_MP.Networking.Packets.World;
+using Shared.Interfaces.Networking;
 
 namespace ONI_MP.DebugTools.UnitTests
 {
@@ -23,15 +24,13 @@ namespace ONI_MP.DebugTools.UnitTests
 			return UnitTestResult.Pass("GroundItemPickedUpPacket roundtrip OK");
 		}
 
-		[UnitTest(name: "GroundItemPickedUpPacket: is IBulkablePacket", category: "GroundItems")]
-		public static UnitTestResult IsBulkable()
+		[UnitTest(name: "GroundItemPickedUpPacket: sends immediately", category: "GroundItems")]
+		public static UnitTestResult SendsImmediately()
 		{
-			var p = new GroundItemPickedUpPacket();
-			if (p.MaxPackSize != 200)
-				return UnitTestResult.Fail($"MaxPackSize expected 200, got {p.MaxPackSize}");
-			if (p.IntervalMs != 200)
-				return UnitTestResult.Fail($"IntervalMs expected 200, got {p.IntervalMs}");
-			return UnitTestResult.Pass($"GroundItemPickedUpPacket IBulkablePacket: MaxPackSize={p.MaxPackSize}, IntervalMs={p.IntervalMs}");
+			if (typeof(IBulkablePacket).IsAssignableFrom(typeof(GroundItemPickedUpPacket)))
+				return UnitTestResult.Fail("GroundItemPickedUpPacket still depends on bulk flushing");
+
+			return UnitTestResult.Pass("GroundItemPickedUpPacket dispatches immediately and stays independent of bulk flush timing");
 		}
 
 		[UnitTest(name: "GroundItems: NetworkIdentityRegistry accessible", category: "GroundItems")]
@@ -50,6 +49,25 @@ namespace ONI_MP.DebugTools.UnitTests
 			if (ClearTool.Instance == null)
 				return UnitTestResult.Fail("ClearTool.Instance is null");
 			return UnitTestResult.Pass("ClearTool.Instance accessible");
+		}
+
+		[UnitTest(name: "GroundItemPickedUpPacket: pending removal queue", category: "GroundItems")]
+		public static UnitTestResult PendingRemovalQueue()
+		{
+			const int testNetId = 424242;
+			GroundItemPickedUpPacket.ClearPending();
+
+			var packet = new GroundItemPickedUpPacket { NetId = testNetId };
+			packet.OnDispatched();
+
+			if (!GroundItemPickedUpPacket.TryConsumePending(testNetId))
+				return UnitTestResult.Fail("Expected pending pickup removal to be queued for unresolved NetId");
+
+			if (GroundItemPickedUpPacket.TryConsumePending(testNetId))
+				return UnitTestResult.Fail("Pending pickup removal should be consumed only once");
+
+			GroundItemPickedUpPacket.ClearPending();
+			return UnitTestResult.Pass("Pending pickup removals queue and consume correctly");
 		}
 	}
 }

--- a/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
+++ b/ClassLibrary1/Networking/NetworkIdentityRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using ONI_MP.DebugTools;
 using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
 using System;
 using System.Collections.Generic;
 using Shared.Profiling;
@@ -117,6 +118,7 @@ namespace ONI_MP.Networking
 
 			identities.Clear();
 			_lookupFailCount = 0;
+			GroundItemPickedUpPacket.ClearPending();
 		}
 
 		public static IEnumerable<NetworkIdentity> AllIdentities => identities.Values;

--- a/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
@@ -1,6 +1,6 @@
 using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.Architecture;
-using Shared.Interfaces.Networking;
+using System.Collections.Generic;
 using System.IO;
 using Shared.Profiling;
 
@@ -8,16 +8,28 @@ namespace ONI_MP.Networking.Packets.World
 {
 	/// <summary>
 	/// Host -> clients: remove a tracked ground item by NetId.
-	/// Batched via IBulkablePacket -- multiple pickups in 200ms window = one message.
 	/// 4 bytes per item. WorldDamageSpawnResourcePacket already assigns matching NetIds
 	/// via identity.OverrideNetId(NetId), so client registry lookup is reliable.
+	/// Keep this packet immediate so the PR does not depend on the separate
+	/// bulk-flush fix branch to dispatch small pickup bursts.
 	/// </summary>
-	public class GroundItemPickedUpPacket : IPacket, IBulkablePacket
+	public class GroundItemPickedUpPacket : IPacket
 	{
+		private static readonly HashSet<int> PendingPickupNetIds = [];
+
 		public int NetId;
 
-		public int MaxPackSize => 200;  // up to 200 items per bulk flush
-		public uint IntervalMs => 200;  // BulkPacketMonitor flush interval (ms)
+		public static bool TryConsumePending(int netId)
+		{
+			using var _ = Profiler.Scope();
+			return PendingPickupNetIds.Remove(netId);
+		}
+
+		public static void ClearPending()
+		{
+			using var _ = Profiler.Scope();
+			PendingPickupNetIds.Clear();
+		}
 
 		public void Serialize(BinaryWriter writer)
 		{
@@ -36,7 +48,11 @@ namespace ONI_MP.Networking.Packets.World
 			using var _ = Profiler.Scope();
 
 			if (!NetworkIdentityRegistry.TryGetComponent<Pickupable>(NetId, out var pickupable))
+			{
+				PendingPickupNetIds.Add(NetId);
+				DebugConsole.LogWarning($"[GroundItemPickedUpPacket] Pickupable NetId {NetId} not yet registered; queued pending removal");
 				return;
+			}
 
 			Util.KDestroyGameObject(pickupable.gameObject);
 		}

--- a/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
@@ -28,7 +28,9 @@ namespace ONI_MP.Networking.Packets.World
 		public static void ClearPending()
 		{
 			using var _ = Profiler.Scope();
+			int n = PendingPickupNetIds.Count;
 			PendingPickupNetIds.Clear();
+			DebugConsole.Log($"[PendingPickup] cleared count={n}");
 		}
 
 		public void Serialize(BinaryWriter writer)

--- a/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
@@ -36,12 +36,8 @@ namespace ONI_MP.Networking.Packets.World
 			using var _ = Profiler.Scope();
 
 			if (!NetworkIdentityRegistry.TryGetComponent<Pickupable>(NetId, out var pickupable))
-			{
-				DebugConsole.LogWarning($"[GroundItemPickedUpPacket] NetId {NetId} not found -- already removed or not tracked");
 				return;
-			}
 
-			DebugConsole.Log($"[GroundItemPickedUpPacket] Removing ground item NetId={NetId} on client");
 			Util.KDestroyGameObject(pickupable.gameObject);
 		}
 	}

--- a/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/GroundItemPickedUpPacket.cs
@@ -1,0 +1,48 @@
+using ONI_MP.DebugTools;
+using ONI_MP.Networking.Packets.Architecture;
+using Shared.Interfaces.Networking;
+using System.IO;
+using Shared.Profiling;
+
+namespace ONI_MP.Networking.Packets.World
+{
+	/// <summary>
+	/// Host -> clients: remove a tracked ground item by NetId.
+	/// Batched via IBulkablePacket -- multiple pickups in 200ms window = one message.
+	/// 4 bytes per item. WorldDamageSpawnResourcePacket already assigns matching NetIds
+	/// via identity.OverrideNetId(NetId), so client registry lookup is reliable.
+	/// </summary>
+	public class GroundItemPickedUpPacket : IPacket, IBulkablePacket
+	{
+		public int NetId;
+
+		public int MaxPackSize => 200;  // up to 200 items per bulk flush
+		public uint IntervalMs => 200;  // BulkPacketMonitor flush interval (ms)
+
+		public void Serialize(BinaryWriter writer)
+		{
+			using var _ = Profiler.Scope();
+			writer.Write(NetId);
+		}
+
+		public void Deserialize(BinaryReader reader)
+		{
+			using var _ = Profiler.Scope();
+			NetId = reader.ReadInt32();
+		}
+
+		public void OnDispatched()
+		{
+			using var _ = Profiler.Scope();
+
+			if (!NetworkIdentityRegistry.TryGetComponent<Pickupable>(NetId, out var pickupable))
+			{
+				DebugConsole.LogWarning($"[GroundItemPickedUpPacket] NetId {NetId} not found -- already removed or not tracked");
+				return;
+			}
+
+			DebugConsole.Log($"[GroundItemPickedUpPacket] Removing ground item NetId={NetId} on client");
+			Util.KDestroyGameObject(pickupable.gameObject);
+		}
+	}
+}

--- a/ClassLibrary1/Networking/Packets/World/WorldDamageSpawnResourcePacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/WorldDamageSpawnResourcePacket.cs
@@ -81,6 +81,13 @@ namespace ONI_MP.Networking.Packets.World
 			identity.OverrideNetId(NetId);
 			DebugConsole.Log("[WorldDamageSpawnResourcePacket] Synchronized Network ID");
 
+			if (GroundItemPickedUpPacket.TryConsumePending(NetId))
+			{
+				DebugConsole.Log($"[WorldDamageSpawnResourcePacket] Consumed pending ground-item pickup for NetId {NetId}");
+				Util.KDestroyGameObject(dropped);
+				return;
+			}
+
 			Pickupable pickup = dropped.GetComponent<Pickupable>();
 			if (pickup != null && pickup.GetMyWorld()?.worldInventory.IsReachable(pickup) == true)
 			{

--- a/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
+++ b/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
@@ -10,6 +10,8 @@ namespace ONI_MP.Patches.World
 	[HarmonyPatch(typeof(Pickupable), "OnCleanUp")]
 	public static class PickupableCleanedUpPatch
 	{
+		private static long _skipCount;
+
 		public static void Postfix(Pickupable __instance)
 		{
 			using var _ = Profiler.Scope();
@@ -20,7 +22,15 @@ namespace ONI_MP.Patches.World
 
 				var identity = __instance.GetComponent<NetworkIdentity>();
 				if (identity == null || identity.NetId == 0)
+				{
+					long n = ++_skipCount;
+					if (n <= 5 || n % 100 == 0)
+					{
+						string name = __instance != null && __instance.gameObject != null ? __instance.gameObject.name : "<null>";
+						DebugConsole.Log($"[GroundPickup] skip NetId=0 name={name} #{n}");
+					}
 					return;
+				}
 
 				PacketSender.SendToAllClients(new GroundItemPickedUpPacket { NetId = identity.NetId });
 			}

--- a/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
+++ b/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
@@ -19,11 +19,10 @@ namespace ONI_MP.Patches.World
 					return;
 
 				var identity = __instance.GetComponent<NetworkIdentity>();
-				if (identity == null)
+				if (identity == null || identity.NetId == 0)
 					return;
 
 				PacketSender.SendToAllClients(new GroundItemPickedUpPacket { NetId = identity.NetId });
-				DebugConsole.Log($"[PickupableCleanedUpPatch] Sent GroundItemPickedUpPacket NetId={identity.NetId}");
 			}
 			catch (System.Exception ex)
 			{

--- a/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
+++ b/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
@@ -1,0 +1,34 @@
+using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.World
+{
+	[HarmonyPatch(typeof(Pickupable), "OnCleanedUp")]
+	public static class PickupableCleanedUpPatch
+	{
+		public static void Postfix(Pickupable __instance)
+		{
+			using var _ = Profiler.Scope();
+			try
+			{
+				if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession)
+					return;
+
+				var identity = __instance.GetComponent<NetworkIdentity>();
+				if (identity == null)
+					return;
+
+				PacketSender.SendToAllClients(new GroundItemPickedUpPacket { NetId = identity.NetId });
+				DebugConsole.Log($"[PickupableCleanedUpPatch] Sent GroundItemPickedUpPacket NetId={identity.NetId}");
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[PickupableCleanedUpPatch] Exception: {ex}");
+			}
+		}
+	}
+}

--- a/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
+++ b/ClassLibrary1/Patches/World/PickupableCleanedUpPatch.cs
@@ -7,7 +7,7 @@ using Shared.Profiling;
 
 namespace ONI_MP.Patches.World
 {
-	[HarmonyPatch(typeof(Pickupable), "OnCleanedUp")]
+	[HarmonyPatch(typeof(Pickupable), "OnCleanUp")]
 	public static class PickupableCleanedUpPatch
 	{
 		public static void Postfix(Pickupable __instance)

--- a/ClassLibrary1/Patches/World/StorageStorePatch.cs
+++ b/ClassLibrary1/Patches/World/StorageStorePatch.cs
@@ -1,0 +1,41 @@
+using HarmonyLib;
+using ONI_MP.DebugTools;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.World;
+using Shared.Profiling;
+using UnityEngine;
+
+namespace ONI_MP.Patches.World
+{
+	// Pickupable.OnCleanUp only fires when the object is destroyed. Items that are
+	// reparented into Storage (seeds into planters, eggs into incubators, live
+	// critters, non-stackable items) stay alive and never trigger OnCleanUp, so
+	// clients keep rendering them on the ground. Mirror the pickup on Store() so
+	// the existing GroundItemPickedUpPacket path removes the client-side ghost.
+	[HarmonyPatch(typeof(Storage), nameof(Storage.Store))]
+	public static class StorageStorePatch
+	{
+		public static void Postfix(GameObject go)
+		{
+			using var _ = Profiler.Scope();
+			try
+			{
+				if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession)
+					return;
+				if (go == null)
+					return;
+
+				var identity = go.GetComponent<NetworkIdentity>();
+				if (identity == null || identity.NetId == 0)
+					return;
+
+				PacketSender.SendToAllClients(new GroundItemPickedUpPacket { NetId = identity.NetId });
+			}
+			catch (System.Exception ex)
+			{
+				DebugConsole.LogError($"[StorageStorePatch] Exception: {ex}");
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When host duplicants picked up ore / ground items, no removal packet was sent to clients, leaving ghost items on the ground indefinitely. A follow-up fix also closes a spawn/pickup race that could produce ghost items even with the packet in place.

### Original fix (`2c9ff5c`, `fb21738`)
- **`GroundItemPickedUpPacket(NetId)`**: host broadcasts item removal on `Pickupable.OnCleanedUp`. Uses `NetId` because `WorldDamageSpawnResourcePacket` already assigns matching NetIds via `OverrideNetId(NetId)`, enabling reliable registry lookup.
- **`PickupableCleanedUpPatch`**: Harmony Postfix on `Pickupable.OnCleanedUp`, host-only, fires for all removal causes (sweep, dupe chore, merge, rot, storage consume, debug destroy) — all of which should mirror to clients.
- **Guards added**: skip broadcast when `NetId == 0` so untracked pickupables do not collide with clients' sentinel entries. Removed per-pickup info logs to stop console spam under sweep bursts.

### Spawn/pickup race fix (`246c36a`)
Ghost items could still appear when the host's pickup arrived on a client **before** the matching spawn packet. The removal packet would find no `Pickupable` in the registry, drop silently, and the drop then spawned uncontested a few ms later — leaving a phantom item on the ground.

- **Drop `IBulkablePacket`**: `GroundItemPickedUpPacket` now dispatches immediately. Decouples this PR from the separate bulk-flush fix (PR #104) and eliminates one source of reorder (bulk flush vs direct-send packet).
- **Pending removal queue**: when `OnDispatched` cannot resolve the NetId, add it to `PendingPickupNetIds` and log a warning instead of silently dropping.
- **`WorldDamageSpawnResourcePacket`**: after `identity.OverrideNetId(NetId)`, consume any pending removal for that NetId and `KDestroyGameObject(dropped)` immediately. Spawn + pickup collapse into a no-op on the client.
- **`NetworkIdentityRegistry.Clear()`** also clears the pending queue so session reset does not leak state.

### Tests (`GroundItemTests`)
- Roundtrip serialize/deserialize
- Asserts packet is **not** `IBulkablePacket` (regression guard)
- Registry accessible + `ClearTool.Instance` accessible
- Pending queue: dispatch with unknown NetId queues it, `TryConsumePending` returns true once then false

Note: `ClearToolPatch` already relays the sweep errand tool client → host, so this packet closes the return path.

## Test plan
- [x] Host dupes pick up ore → clients see item removed, no ghost
- [x] Client sweeps area → host executes, clients see removal
- [ ] Untracked pickupable destruction (`NetId=0`) does not broadcast
- [ ] World damage spawn → immediate client-side pickup (same tick): item never appears (pending-queue path)
- [ ] Session reset / disconnect clears pending queue (no stale entries)
