### PR TITLE
fix: batch drag-tool commands via IBulkablePacket

### DIFF
--- a/ClassLibrary1/DebugTools/SyncStats.cs
+++ b/ClassLibrary1/DebugTools/SyncStats.cs
@@ -33,6 +33,8 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric Structures = new SyncMetric { Name = "Structures", Interval = 0.5f };
 		public static SyncMetric VitalStats = new SyncMetric { Name = "VitalStats", Interval = 1f };
 		public static SyncMetric Plants = new SyncMetric { Name = "Plants", Interval = 5f };
+		// DragTool: bulk flush observability (count = cells batched in last flush, bytes = payload).
+		public static SyncMetric DragTool = new SyncMetric { Name = "DragTool", Interval = 0.1f };
 
 		/// <summary>
 		/// Updates a metric after a sync operation.
@@ -53,7 +55,8 @@ namespace ONI_MP.DebugTools
 		public static SyncMetric[] AllMetrics => new[]
 		{
 			Gas, Digging, Chores, Research,
-			Buildings, Structures, VitalStats, Plants
+			Buildings, Structures, VitalStats, Plants,
+			DragTool
 		};
 	}
 }

--- a/ClassLibrary1/Networking/Components/BulkPacketMonitor.cs
+++ b/ClassLibrary1/Networking/Components/BulkPacketMonitor.cs
@@ -10,7 +10,8 @@ namespace ONI_MP.Networking.Components
 {
 	internal class BulkPacketMonitor : MonoBehaviour
 	{
-		private float updateIntervalSeconds = 0.2f;
+		// Poll often enough for 100ms bulk packets while leaving pacing to PacketSender.
+		private float updateIntervalSeconds = 0.1f;
 		private float updateTimer;
 
 		public void LateUpdate()

--- a/ClassLibrary1/Networking/Components/BulkPacketMonitor.cs
+++ b/ClassLibrary1/Networking/Components/BulkPacketMonitor.cs
@@ -15,8 +15,6 @@ namespace ONI_MP.Networking.Components
 
 		public void LateUpdate()
 		{
-			return;
-
 			if (!MultiplayerSession.InSession)
 				return;
 

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -70,6 +70,9 @@ namespace ONI_MP.Networking
 		static Dictionary<object, Dictionary<int, List<byte[]>>> WaitingBulkPacketsPerReceiver = [];
 		// Running byte total per (receiver, packetId) so LAN capacity checks stay O(1) per append.
 		static Dictionary<object, Dictionary<int, int>> WaitingBulkPacketBytes = [];
+		// Packet ids that belong to DragToolPacket subclasses — tagged lazily on first append
+		// so the bulk flush site can record SyncStats.DragTool without needing the typed instance.
+		static HashSet<int> DragToolBulkPacketIds = new HashSet<int>();
 		public static void DispatchPendingBulkPackets()
 		{
 			using var _ = Profiler.Scope();
@@ -106,16 +109,26 @@ namespace ONI_MP.Networking
 			}
 			if (intervalRun && UpdateRunners.TryGetValue(packetId, out var intervalRunner) && !intervalRunner.CanDispatchNext(conn))
 				return;
+
+			int flushCount = pendingPackets.Count;
+			int flushBytes = 0;
+			WaitingBulkPacketBytes.TryGetValue(conn, out var byteTotals);
+			if (byteTotals != null && byteTotals.TryGetValue(packetId, out var bt))
+				flushBytes = bt;
+			var swFlush = System.Diagnostics.Stopwatch.StartNew();
 			SendToConnection(conn, new BulkSenderPacket(packetId, pendingPackets), PacketSendMode.ReliableImmediate);
+			swFlush.Stop();
 			pendingPackets.Clear();
 			allPendingPackets.Remove(packetId);
-			if (WaitingBulkPacketBytes.TryGetValue(conn, out var byteTotals))
+			if (byteTotals != null)
 			{
 				byteTotals[packetId] = 0;
 				byteTotals.Remove(packetId);
 			}
 			if (UpdateRunners.TryGetValue(packetId, out var runner))
 				runner.RecordDispatch(conn);
+			if (DragToolBulkPacketIds.Contains(packetId))
+				SyncStats.RecordSync(SyncStats.DragTool, flushCount, flushBytes, (float)swFlush.Elapsed.TotalMilliseconds);
 		}
 		public static void AppendPendingBulkPacket(object conn, IPacket packet, IBulkablePacket bp)
 		{
@@ -123,6 +136,9 @@ namespace ONI_MP.Networking
 
 			int packetId = PacketRegistry.GetPacketId(packet);
 			int maxPacketNumberPerPacket = bp.MaxPackSize;
+
+			if (packet is ONI_MP.Networking.Packets.Tools.DragToolPacket)
+				DragToolBulkPacketIds.Add(packetId);
 
 			if (!UpdateRunners.ContainsKey(packetId))
 			{

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -76,6 +76,8 @@ namespace ONI_MP.Networking
 
 		static Dictionary<int, PacketUpdateRunner> UpdateRunners = [];
 		static Dictionary<object, Dictionary<int, List<byte[]>>> WaitingBulkPacketsPerReceiver = [];
+		// Running byte total per (receiver, packetId) so LAN capacity checks stay O(1) per append.
+		static Dictionary<object, Dictionary<int, int>> WaitingBulkPacketBytes = [];
 		public static void DispatchPendingBulkPackets()
 		{
 			using var _ = Profiler.Scope();
@@ -107,6 +109,8 @@ namespace ONI_MP.Networking
 			//}
 			SendToConnection(conn, new BulkSenderPacket(packetId, pendingPackets), PacketSendMode.ReliableImmediate);
 			pendingPackets.Clear();
+			if (WaitingBulkPacketBytes.TryGetValue(conn, out var byteTotals))
+				byteTotals[packetId] = 0;
 		}
 		public static void AppendPendingBulkPacket(object conn, IPacket packet, IBulkablePacket bp)
 		{
@@ -130,18 +134,28 @@ namespace ONI_MP.Networking
 				bulkPacketWaitingData[packetId] = new List<byte[]>(maxPacketNumberPerPacket);
 				pendingPackets = bulkPacketWaitingData[packetId];
 			}
-			pendingPackets.Add(packet.SerializeToByteArray());
+			var serialized = packet.SerializeToByteArray();
+			pendingPackets.Add(serialized);
+
+			if (!WaitingBulkPacketBytes.TryGetValue(conn, out var byteTotals))
+			{
+				byteTotals = [];
+				WaitingBulkPacketBytes[conn] = byteTotals;
+			}
+			if (!byteTotals.TryGetValue(packetId, out var runningTotal))
+				runningTotal = 4; // +4 for the packetId int header
+			runningTotal += serialized.Length;
+			byteTotals[packetId] = runningTotal;
 
 			bool atCapacity = false;
 			if (NetworkConfig.IsLanConfig())
 			{
 				float maxSize = MAX_PACKET_SIZE_LAN * 1024f;
-                int totalSize = pendingPackets.Sum(p => p.Length) + 4; // +4 for the packetId int
-                if (totalSize >= maxSize)
-                {
-                    atCapacity = true;
-                }
-            }
+				if (runningTotal >= maxSize)
+				{
+					atCapacity = true;
+				}
+			}
 
 			if (pendingPackets.Count >= maxPacketNumberPerPacket || atCapacity)
 			{

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -19,39 +19,31 @@ namespace ONI_MP.Networking
 {
 	public static class PacketSender
 	{
-		/// <summary>
-		/// Sth in this is broken
-		/// </summary>
 		private class PacketUpdateRunner
 		{
-			int PacketId;
-			float UpdateIntervalS;
-
-			Dictionary<HSteamNetConnection, float> LastDispatchTime = [];
+			private readonly float _updateIntervalS;
+			private readonly Dictionary<object, float> _lastDispatchTime = [];
 
 			public PacketUpdateRunner(int packetId, uint updateInterval)
 			{
-				PacketId = packetId;
-				UpdateIntervalS = updateInterval/1000f;
+				_updateIntervalS = updateInterval / 1000f;
 			}
-			public bool CanDispatchNext(HSteamNetConnection connection)
+
+			public bool CanDispatchNext(object connection)
 			{
 				using var _ = Profiler.Scope();
 
-				var currentTime = Time.unscaledTime;
-
-				if (!LastDispatchTime.ContainsKey(connection))
-				{
-					LastDispatchTime[connection] = currentTime;
+				if (!_lastDispatchTime.TryGetValue(connection, out var lastDispatchTime))
 					return true;
-				}
 
-				if (LastDispatchTime[connection] + UpdateIntervalS > currentTime)
-				{
-					LastDispatchTime[connection] = currentTime;
-					return true;
-				}
-				return false;
+				return Time.unscaledTime - lastDispatchTime >= _updateIntervalS;
+			}
+
+			public void RecordDispatch(object connection)
+			{
+				using var _ = Profiler.Scope();
+
+				_lastDispatchTime[connection] = Time.unscaledTime;
 			}
 		}
 
@@ -82,13 +74,23 @@ namespace ONI_MP.Networking
 		{
 			using var _ = Profiler.Scope();
 
+			var emptyConnections = new List<object>();
 			foreach (var kvp in WaitingBulkPacketsPerReceiver)
 			{
 				var conn = kvp.Key;
-				foreach (var packetId in kvp.Value.Keys)
+				foreach (var packetId in kvp.Value.Keys.ToList())
 				{
 					DispatchPendingBulkPacketOfType(conn, packetId, true);
 				}
+
+				if (kvp.Value.Count == 0)
+					emptyConnections.Add(conn);
+			}
+
+			foreach (var conn in emptyConnections)
+			{
+				WaitingBulkPacketsPerReceiver.Remove(conn);
+				WaitingBulkPacketBytes.Remove(conn);
 			}
 		}
 
@@ -102,15 +104,18 @@ namespace ONI_MP.Networking
 			{
 				return;
 			}
-			//if (intervalRun)
-			//{
-			//	if (!UpdateRunners[packetId].CanDispatchNext(conn))
-			//		return;
-			//}
+			if (intervalRun && UpdateRunners.TryGetValue(packetId, out var intervalRunner) && !intervalRunner.CanDispatchNext(conn))
+				return;
 			SendToConnection(conn, new BulkSenderPacket(packetId, pendingPackets), PacketSendMode.ReliableImmediate);
 			pendingPackets.Clear();
+			allPendingPackets.Remove(packetId);
 			if (WaitingBulkPacketBytes.TryGetValue(conn, out var byteTotals))
+			{
 				byteTotals[packetId] = 0;
+				byteTotals.Remove(packetId);
+			}
+			if (UpdateRunners.TryGetValue(packetId, out var runner))
+				runner.RecordDispatch(conn);
 		}
 		public static void AppendPendingBulkPacket(object conn, IPacket packet, IBulkablePacket bp)
 		{

--- a/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
+++ b/ClassLibrary1/Networking/Packets/Architecture/PacketSender.cs
@@ -332,7 +332,7 @@ namespace ONI_MP.Networking
 
 			if (MultiplayerSession.IsHost)
 				SendToAllClients(packet);
-			else if (packet is IBulkablePacket)
+			else if (packet is IBulkablePacket && packet is not IClientRelayable)
 				SendToHost(packet);
 			else
 				SendToHost(new HostBroadcastPacket(packet, MultiplayerSession.LocalUserID));

--- a/ClassLibrary1/Networking/Packets/InstantiationsPacket.cs
+++ b/ClassLibrary1/Networking/Packets/InstantiationsPacket.cs
@@ -10,6 +10,9 @@ namespace ONI_MP.Networking.Packets
 {
 	public class InstantiationsPacket : IPacket
 	{
+		private const int MaxCompressedBytes = 16 * 1024 * 1024;
+		private const int MaxInstantiationCount = 8192;
+
 		public List<InstantiationEntry> Entries = new List<InstantiationEntry>();
 
 		public struct InstantiationEntry
@@ -56,6 +59,12 @@ namespace ONI_MP.Networking.Packets
 			using var _ = Profiler.Scope();
 
 			int compressedLength = r.ReadInt32();
+			if (compressedLength < 0 || compressedLength > MaxCompressedBytes)
+			{
+				DebugConsole.LogWarning($"[InstantiationsPacket] Invalid compressed payload length: {compressedLength}");
+				Entries = [];
+				return;
+			}
 			byte[] compressedData = r.ReadBytes(compressedLength);
 
 			using (var ms = new MemoryStream(compressedData))
@@ -65,6 +74,12 @@ namespace ONI_MP.Networking.Packets
 					using (var tempReader = new BinaryReader(deflate))
 					{
 						int count = tempReader.ReadInt32();
+						if (count < 0 || count > MaxInstantiationCount)
+						{
+							DebugConsole.LogWarning($"[InstantiationsPacket] Invalid instantiation count: {count}");
+							Entries = [];
+							return;
+						}
 						Entries = new List<InstantiationEntry>(count);
 
 						for (int i = 0; i < count; i++)

--- a/ClassLibrary1/Networking/Packets/Tools/Attack/AttackToolPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Attack/AttackToolPacket.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using HarmonyLib;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.Architecture;
 using Shared.Profiling;
 using Steamworks;
@@ -12,7 +13,7 @@ public class AttackToolPacket : IPacket
     private ulong        SenderId = MultiplayerSession.LocalUserID;
     private Vector2         Min;
     private Vector2         Max;
-    private PrioritySetting Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
+    private PrioritySetting Priority;
 
     public AttackToolPacket()
     {
@@ -29,6 +30,9 @@ public class AttackToolPacket : IPacket
     public void Serialize(BinaryWriter writer)
     {
         using var _ = Profiler.Scope();
+
+        if (ToolMenu.Instance?.PriorityScreen != null)
+            Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
 
         writer.Write(SenderId);
         writer.Write(Min);
@@ -51,13 +55,25 @@ public class AttackToolPacket : IPacket
     {
         using var _ = Profiler.Scope();
 
-        Traverse        lastSelectedPriority = Traverse.Create(ToolMenu.Instance.PriorityScreen).Field("lastSelectedPriority");
+        var priorityScreen = ToolMenu.Instance?.PriorityScreen;
+        if (priorityScreen == null)
+        {
+            DebugConsole.LogWarning("[AttackToolPacket] PriorityScreen is null in OnDispatched; applying attack without overriding priority");
+            AttackTool.MarkForAttack(Min, Max, true);
+            return;
+        }
+
+        Traverse        lastSelectedPriority = Traverse.Create(priorityScreen).Field("lastSelectedPriority");
         PrioritySetting prioritySetting      = lastSelectedPriority.GetValue<PrioritySetting>();
 
         lastSelectedPriority.SetValue(Priority);
-
-        AttackTool.MarkForAttack(Min, Max, true);
-
-        lastSelectedPriority.SetValue(prioritySetting);
+        try
+        {
+            AttackTool.MarkForAttack(Min, Max, true);
+        }
+        finally
+        {
+            lastSelectedPriority.SetValue(prioritySetting);
+        }
     }
 }

--- a/ClassLibrary1/Networking/Packets/Tools/Build/BuildCompletePacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Build/BuildCompletePacket.cs
@@ -10,6 +10,8 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 {
 	public class BuildCompletePacket : IPacket
 	{
+		private const int MaxMaterialTagCount = 64;
+
 		public int Cell;
 		public string PrefabID;
 		public Orientation Orientation;
@@ -55,6 +57,13 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 			FacadeID = reader.ReadString();
 
 			int count = reader.ReadInt32();
+			if (count < 0 || count > MaxMaterialTagCount)
+			{
+				DebugConsole.LogWarning($"[BuildCompletePacket] Invalid material tag count: {count}");
+				Cell = Grid.InvalidCell;
+				MaterialTags = [];
+				return;
+			}
 			MaterialTags = new List<string>(count);
 			for (int i = 0; i < count; i++)
 				MaterialTags.Add(reader.ReadString());

--- a/ClassLibrary1/Networking/Packets/Tools/Build/BuildPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Build/BuildPacket.cs
@@ -11,6 +11,8 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 {
     public class BuildPacket : IPacket
     {
+        private const int MaxMaterialTagCount = 64;
+
         private string          PrefabID;
         private int             Cell;
         private Orientation     Orientation;
@@ -57,6 +59,13 @@ namespace ONI_MP.Networking.Packets.Tools.Build
             Cell        = reader.ReadInt32();
             Orientation = (Orientation)reader.ReadInt32();
             int count = reader.ReadInt32();
+            if (count < 0 || count > MaxMaterialTagCount)
+            {
+                DebugConsole.LogWarning($"[BuildPacket] Invalid material tag count: {count}");
+                Cell = Grid.InvalidCell;
+                MaterialTags = [];
+                return;
+            }
             MaterialTags = new List<string>();
             for (int i = 0; i < count; i++)
                 MaterialTags.Add(reader.ReadString());

--- a/ClassLibrary1/Networking/Packets/Tools/Build/UtilityBuildPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Build/UtilityBuildPacket.cs
@@ -13,6 +13,9 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 {
 	public class UtilityBuildPacket : IPacket
 	{
+		private const int MaxPathNodeCount = 8192;
+		private const int MaxMaterialTagCount = 64;
+
 		/// <summary>
 		/// Gets a value indicating whether incoming messages are currently being processed.
 		/// Use in patches to prevent recursion when applying tool changes.
@@ -98,6 +101,13 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 			//DebugConsole.Log("[UtilityBuildPacket] FacadeID read successfully: " + FacadeID);
 			//DebugConsole.Log("[UtilityBuildPacket] Reading path Count...");
 			int count = reader.ReadInt32();
+			if (count < 0 || count > MaxPathNodeCount)
+			{
+				DebugConsole.LogWarning($"[UtilityBuildPacket] Invalid path node count: {count}");
+				path = [];
+				MaterialTags = [];
+				return;
+			}
 			//DebugConsole.Log("[UtilityBuildPacket] path Count read successfully: " + count);
 			path = new List<BaseUtilityBuildTool.PathNode>(count);
 			for (int i = 0; i < count; i++)
@@ -107,6 +117,13 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 			}
 			//DebugConsole.Log("[UtilityBuildPacket] Reading matCount...");
 			int matCount = reader.ReadInt32();
+			if (matCount < 0 || matCount > MaxMaterialTagCount)
+			{
+				DebugConsole.LogWarning($"[UtilityBuildPacket] Invalid material tag count: {matCount}");
+				path = [];
+				MaterialTags = [];
+				return;
+			}
 			//DebugConsole.Log("[UtilityBuildPacket] matCount read successfully: " + matCount);
 			MaterialTags = new List<string>(matCount);
 			if (matCount > 0)
@@ -173,21 +190,26 @@ namespace ONI_MP.Networking.Packets.Tools.Build
 			tool.conduitMgr = conduitManagerHaver.GetNetworkManager();
 
 			ProcessingIncoming = true;
-			DebugConsole.Log($"[UtilityBuildPacket] Building path with {path.Count} nodes of prefab {def.PrefabID}");
-			tool.BuildPath();
-
-			foreach (BaseUtilityBuildTool.PathNode node in path)
+			try
 			{
-				GameObject    gameObject    = Grid.Objects[node.cell, (int)def.TileLayer];
-				Prioritizable prioritizable = gameObject?.GetComponent<Prioritizable>();
-				prioritizable?.SetMasterPriority(Priority);
-			}
-			ProcessingIncoming = false;
+				DebugConsole.Log($"[UtilityBuildPacket] Building path with {path.Count} nodes of prefab {def.PrefabID}");
+				tool.BuildPath();
 
-			tool.def = cachedDef;
-			tool.path = cachedPath;
-			tool.selectedElements = cachedMaterials;
-			tool.conduitMgr = cachedMgr;
+				foreach (BaseUtilityBuildTool.PathNode node in path)
+				{
+					GameObject    gameObject    = Grid.Objects[node.cell, (int)def.TileLayer];
+					Prioritizable prioritizable = gameObject?.GetComponent<Prioritizable>();
+					prioritizable?.SetMasterPriority(Priority);
+				}
+			}
+			finally
+			{
+				ProcessingIncoming = false;
+				tool.def = cachedDef;
+				tool.path = cachedPath;
+				tool.selectedElements = cachedMaterials;
+				tool.conduitMgr = cachedMgr;
+			}
 		}
 	}
 }

--- a/ClassLibrary1/Networking/Packets/Tools/Capture/CaptureToolPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Capture/CaptureToolPacket.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using HarmonyLib;
+using ONI_MP.DebugTools;
 using ONI_MP.Networking.Packets.Architecture;
 using Shared.Profiling;
 using Steamworks;
@@ -12,7 +13,7 @@ public class CaptureToolPacket : IPacket
     private ulong        SenderId = MultiplayerSession.LocalUserID;
     private Vector2         Min;
     private Vector2         Max;
-    private PrioritySetting Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
+    private PrioritySetting Priority;
 
     public CaptureToolPacket()
     {
@@ -29,6 +30,9 @@ public class CaptureToolPacket : IPacket
     public void Serialize(BinaryWriter writer)
     {
         using var _ = Profiler.Scope();
+
+        if (ToolMenu.Instance?.PriorityScreen != null)
+            Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
 
         writer.Write(SenderId);
         writer.Write(Min);
@@ -51,13 +55,25 @@ public class CaptureToolPacket : IPacket
     {
         using var _ = Profiler.Scope();
 
-        Traverse        lastSelectedPriority = Traverse.Create(ToolMenu.Instance.PriorityScreen).Field("lastSelectedPriority");
+        var priorityScreen = ToolMenu.Instance?.PriorityScreen;
+        if (priorityScreen == null)
+        {
+            DebugConsole.LogWarning("[CaptureToolPacket] PriorityScreen is null in OnDispatched; applying capture without overriding priority");
+            CaptureTool.MarkForCapture(Min, Max, true);
+            return;
+        }
+
+        Traverse        lastSelectedPriority = Traverse.Create(priorityScreen).Field("lastSelectedPriority");
         PrioritySetting prioritySetting      = lastSelectedPriority.GetValue<PrioritySetting>();
 
         lastSelectedPriority.SetValue(Priority);
-
-        CaptureTool.MarkForCapture(Min, Max, true);
-
-        lastSelectedPriority.SetValue(prioritySetting);
+        try
+        {
+            CaptureTool.MarkForCapture(Min, Max, true);
+        }
+        finally
+        {
+            lastSelectedPriority.SetValue(prioritySetting);
+        }
     }
 }

--- a/ClassLibrary1/Networking/Packets/Tools/Dig/DiggablePacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/Dig/DiggablePacket.cs
@@ -15,7 +15,7 @@ namespace ONI_MP.Networking.Packets.Tools.Dig
 
         private int             Cell;
         private int             AnimationDelay;
-        private PrioritySetting Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
+        private PrioritySetting Priority;
 
         public DiggablePacket()
         {
@@ -32,6 +32,9 @@ namespace ONI_MP.Networking.Packets.Tools.Dig
         public void Serialize(BinaryWriter writer)
         {
             using var _ = Profiler.Scope();
+
+            if (ToolMenu.Instance?.PriorityScreen != null)
+                Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
 
             writer.Write(Cell);
             writer.Write(AnimationDelay);
@@ -52,9 +55,16 @@ namespace ONI_MP.Networking.Packets.Tools.Dig
         {
             using var _ = Profiler.Scope();
 
+            GameObject game_object;
             ProcessingIncoming = true;
-            GameObject game_object = DigTool.PlaceDig(Cell, AnimationDelay);
-            ProcessingIncoming = false;
+            try
+            {
+                game_object = DigTool.PlaceDig(Cell, AnimationDelay);
+            }
+            finally
+            {
+                ProcessingIncoming = false;
+            }
 
             Prioritizable prioritizable = game_object?.GetComponent<Prioritizable>();
             prioritizable?.SetMasterPriority(Priority);

--- a/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
@@ -7,14 +7,21 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using HarmonyLib;
+using Shared.Interfaces.Networking;
 using Shared.Profiling;
 using UnityEngine;
 using static STRINGS.INPUT_BINDINGS;
 
 namespace ONI_MP.Networking.Packets.Tools
 {
-	public abstract class DragToolPacket : IPacket
+	public abstract class DragToolPacket : IPacket, IBulkablePacket, IClientRelayable
 	{
+		// Per-cell OnDragTool fires once per frame during a drag. Batching
+		// coalesces the fan-out leg (host -> N clients) and the host-receive
+		// side so a 60-cell drag becomes ~1 bulk message instead of 60.
+		public int MaxPackSize => 64;
+		public uint IntervalMs => 100;
+
 		/// <summary>
 		/// Gets a value indicating whether incoming messages are currently being processed.
 		/// Use in patches to prevent recursion when applying tool changes.

--- a/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
@@ -28,6 +28,8 @@ namespace ONI_MP.Networking.Packets.Tools
 		/// </summary>
 		public static bool ProcessingIncoming { get; private set; } = false;
 
+		private static long _restoredCount;
+
 		public enum DragToolMode
 		{
 			Invalid = -1,
@@ -144,6 +146,7 @@ namespace ONI_MP.Networking.Packets.Tools
 
 			Vector3 cachedDownPos = ToolInstance.downPos;
 			ProcessingIncoming = true;
+			bool completed = false;
 			try
 			{
 				switch (ToolMode)
@@ -161,11 +164,20 @@ namespace ONI_MP.Networking.Packets.Tools
 						DebugConsole.LogWarning("[FilteredDragToolPacket] OnDispatched called with invalid ToolMode");
 						break;
 				}
+				completed = true;
 			}
 			finally
 			{
 				ToolInstance.downPos = cachedDownPos;
+				// Always restore; otherwise a throw inside the tool's OnDragTool leaves the
+				// receiver-side guard stuck at true and every subsequent drag is silently dropped.
 				ProcessingIncoming = false;
+				if (!completed)
+				{
+					long n = System.Threading.Interlocked.Increment(ref _restoredCount);
+					if (n <= 5 || n % 100 == 0)
+						DebugConsole.LogWarning($"[DragTool] ProcessingIncoming restored after exception #{n}");
+				}
 				if (hasPriorityScreen)
 					lastSelectedPriority.SetValue(prioritySetting);
 

--- a/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
+++ b/ClassLibrary1/Networking/Packets/Tools/DragToolPacket.cs
@@ -42,11 +42,14 @@ namespace ONI_MP.Networking.Packets.Tools
 		HashSet<string> currentFilterTargets = [];
 		public Vector3 downPos, upPos;
 		public int cell, distFromOrigin;
-		private PrioritySetting Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
+		private PrioritySetting Priority;
 
 		public virtual void Serialize(BinaryWriter writer)
 		{
 			using var _ = Profiler.Scope();
+
+			if (ToolMenu.Instance?.PriorityScreen != null)
+				Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority();
 
 			if(ToolInstance is FilteredDragTool filteredToolInstance)
 				StoreFilterData(filteredToolInstance);
@@ -112,6 +115,7 @@ namespace ONI_MP.Networking.Packets.Tools
 			if (ToolInstance == null)
 			{
 				DebugConsole.LogWarning("[FilteredDragToolPacket] ToolInstance is null in OnDispatched");
+				return;
 			}
 
 			FilteredDragTool filteredToolInstance = ToolInstance as FilteredDragTool;
@@ -123,35 +127,51 @@ namespace ONI_MP.Networking.Packets.Tools
 				ApplyFilterData(filteredToolInstance, currentFilterTargets);
 			}
 
-			Traverse        lastSelectedPriority = Traverse.Create(ToolMenu.Instance.PriorityScreen).Field("lastSelectedPriority");
-			PrioritySetting prioritySetting      = lastSelectedPriority.GetValue<PrioritySetting>();
-
-			lastSelectedPriority.SetValue(Priority);
-
-			ProcessingIncoming = true;
-			switch (ToolMode)
+			var priorityScreen = ToolMenu.Instance?.PriorityScreen;
+			Traverse lastSelectedPriority = null;
+			PrioritySetting prioritySetting = default;
+			bool hasPriorityScreen = priorityScreen != null;
+			if (hasPriorityScreen)
 			{
-				case DragToolMode.OnDragTool:
-					DebugConsole.Log($"[FilteredDragToolPacket] OnDispatched OnDragTool - cell: {cell}, distFromOrigin: {distFromOrigin}");
-					ToolInstance.OnDragTool(cell, distFromOrigin);
-					break;
-				case DragToolMode.OnDragComplete:
-					Vector3 cachedDownPos = ToolInstance.downPos;
-					ToolInstance.downPos = downPos;
-					DebugConsole.Log($"[FilteredDragToolPacket] OnDispatched OnDragComplete - startPos: {downPos}, endPos: {upPos}");
-					ToolInstance.OnDragComplete(downPos, upPos);
-					ToolInstance.downPos = cachedDownPos;
-					break;
-				default:
-					DebugConsole.LogWarning("[FilteredDragToolPacket] OnDispatched called with invalid ToolMode");
-					break;
+				lastSelectedPriority = Traverse.Create(priorityScreen).Field("lastSelectedPriority");
+				prioritySetting = lastSelectedPriority.GetValue<PrioritySetting>();
+				lastSelectedPriority.SetValue(Priority);
 			}
-			ProcessingIncoming = false;
+			else
+			{
+				DebugConsole.LogWarning("[FilteredDragToolPacket] PriorityScreen is null in OnDispatched; applying tool without overriding priority");
+			}
 
-			lastSelectedPriority.SetValue(prioritySetting);
+			Vector3 cachedDownPos = ToolInstance.downPos;
+			ProcessingIncoming = true;
+			try
+			{
+				switch (ToolMode)
+				{
+					case DragToolMode.OnDragTool:
+						DebugConsole.Log($"[FilteredDragToolPacket] OnDispatched OnDragTool - cell: {cell}, distFromOrigin: {distFromOrigin}");
+						ToolInstance.OnDragTool(cell, distFromOrigin);
+						break;
+					case DragToolMode.OnDragComplete:
+						ToolInstance.downPos = downPos;
+						DebugConsole.Log($"[FilteredDragToolPacket] OnDispatched OnDragComplete - startPos: {downPos}, endPos: {upPos}");
+						ToolInstance.OnDragComplete(downPos, upPos);
+						break;
+					default:
+						DebugConsole.LogWarning("[FilteredDragToolPacket] OnDispatched called with invalid ToolMode");
+						break;
+				}
+			}
+			finally
+			{
+				ToolInstance.downPos = cachedDownPos;
+				ProcessingIncoming = false;
+				if (hasPriorityScreen)
+					lastSelectedPriority.SetValue(prioritySetting);
 
-			if (isFilteredTool)
-				ApplyFilterData(filteredToolInstance, cachedFilters);
+				if (isFilteredTool)
+					ApplyFilterData(filteredToolInstance, cachedFilters);
+			}
 		}
 		public void ApplyFilterData(FilteredDragTool tool, HashSet<string> targets)
 		{

--- a/ClassLibrary1/Networking/Packets/World/WorldDataPacket.cs
+++ b/ClassLibrary1/Networking/Packets/World/WorldDataPacket.cs
@@ -10,6 +10,9 @@ namespace ONI_MP.Networking.Packets.World
 {
 	public class WorldDataPacket : IPacket
 	{
+		private const int MaxCompressedBytes = 32 * 1024 * 1024;
+		private const int MaxChunkCount = 16384;
+
 		public List<ChunkData> Chunks = new List<ChunkData>();
 
 		public void Serialize(BinaryWriter writer)
@@ -47,6 +50,12 @@ namespace ONI_MP.Networking.Packets.World
 			using var _ = Profiler.Scope();
 
 			int compressedLength = reader.ReadInt32();
+			if (compressedLength < 0 || compressedLength > MaxCompressedBytes)
+			{
+				DebugConsole.LogWarning($"[WorldDataPacket] Invalid compressed payload length: {compressedLength}");
+				Chunks = [];
+				return;
+			}
 			byte[] compressedData = reader.ReadBytes(compressedLength);
 
 			using (var memoryStream = new MemoryStream(compressedData))
@@ -54,6 +63,12 @@ namespace ONI_MP.Networking.Packets.World
 			using (var decompressReader = new BinaryReader(decompressStream))
 			{
 				int count = decompressReader.ReadInt32();
+				if (count < 0 || count > MaxChunkCount)
+				{
+					DebugConsole.LogWarning($"[WorldDataPacket] Invalid chunk count: {count}");
+					Chunks = [];
+					return;
+				}
 				Chunks = new List<ChunkData>(count);
 				for (int i = 0; i < count; i++)
 				{

--- a/Shared/Interfaces/Networking/IClientRelayable.cs
+++ b/Shared/Interfaces/Networking/IClientRelayable.cs
@@ -1,0 +1,12 @@
+namespace Shared.Interfaces.Networking
+{
+	/// <summary>
+	/// Marks a packet that a client sends via SendToAllOtherPeers and expects
+	/// the host to rebroadcast to other clients (command relay semantics).
+	/// Without this marker, IBulkablePacket takes a direct path to the host
+	/// that skips the HostBroadcastPacket wrapper and therefore the rebroadcast.
+	/// </summary>
+	public interface IClientRelayable
+	{
+	}
+}


### PR DESCRIPTION
## Summary

Drag tools (sweep / mop / dig / build / deconstruct / harvest / prioritize / attack / capture / etc.) fire `OnDragTool` once per cell visited by the cursor. A 60-cell sweep drag produced **60 individual Reliable sends to every peer**, each ~40 bytes. With 4 clients: 60 × 3 = 180 packet dispatches per drag. Packet-count is the real cost — transport overhead per packet dominates the payload.

A follow-up commit adds the missing interval gate, deserialization bounds, and try/finally safety on tool state.

### Batching (`273c27b`, `46b5aa3`)

- **`DragToolPacket` now `: IPacket, IBulkablePacket, IClientRelayable`** (`MaxPackSize=64`, `IntervalMs=100`). Every subclass (`ClearPacket`, `MopToolPacket`, `DiggablePacket`, `DeconstructPacket`, `HarvestToolPacket`, `PrioritizePacket`, `BuildPacket`, `CancelPacket`, `AttackToolPacket`, `CaptureToolPacket`, `CopySettingsToolPacket`, `DisinfectPacket`, `MoveToLocationPacket`, `UtilityBuildPacket`) inherits batching automatically.
- **New `IClientRelayable` marker.** `PacketSender.SendToAllOtherPeers` previously short-circuited every `IBulkablePacket` past the `HostBroadcastPacket` wrapper, which would break client → host → other-clients relay. The marker lets bulkable packets opt back into the relay path while still batching on every `SendToConnection`.
- **Re-enable `BulkPacketMonitor.LateUpdate` periodic flush.** It was early-returning, so bulk queues only dispatched when `MaxPackSize` was reached. Small batches (under cap) never flushed. The 200 ms periodic flush is now active for all bulkable packets (drag tools, `PlayAnimPacket`, `SymbolOverridePacket`, `StatusItemGroupPacket`, `GroundItemPickedUpPacket`, etc.). This also fixes a latent bug where short sequences of existing bulk packets could stall in queue.
- **O(1) pending bulk byte total** in `PacketSender` (`46b5aa3`) — avoids a linear scan over every queued bulk packet each time we check the per-connection byte cap.

### Stability follow-up (`9989637`)

- **`PacketSender`**: the original `CanDispatchNext` interval gate was inverted (`last + interval > current` returning `true`) and had been commented out with a `// Sth in this is broken` note. Split into `CanDispatchNext` (read-only check `unscaledTime - last >= interval`) and `RecordDispatch` (write), then re-enable the check on the `intervalRun` path. Also cleans up empty per-connection buckets after flush and switches the dispatch key to `object` to match the rest of the sender.
- **`BulkPacketMonitor`**: poll interval `0.2s → 0.1s` so bulk packets with `IntervalMs=100` are actually dispatched at their declared cadence instead of ~200 ms.
- **Tool packets lazy-init `Priority`**: `AttackToolPacket`, `CaptureToolPacket`, `DiggablePacket`, `DragToolPacket`, `UtilityBuildPacket` previously initialized `Priority = ToolMenu.Instance.PriorityScreen.GetLastSelectedPriority()` as a field initializer, which ran on **deserialization** too — NRE on clients where `ToolMenu.Instance` isn't ready. Moved into `Serialize` with a null guard.
- **Try/finally around tool state**: `OnDispatched` now restores `lastSelectedPriority`, `tool.downPos`, `ProcessingIncoming`, and `UtilityBuild` fields (`def`, `path`, `selectedElements`, `conduitMgr`) inside `finally`, so a throw in `MarkForAttack` / `PlaceDig` / `BuildPath` no longer poisons global tool state.
- **`DragToolPacket`**: `ToolInstance == null` now `return;` (previous code warned and continued to NRE).
- **Deserialize bounds (fail-closed)**:
  - `BuildPacket`, `BuildCompletePacket`: `MaterialTags ≤ 64`
  - `UtilityBuildPacket`: `path ≤ 8192`, `MaterialTags ≤ 64`
  - `InstantiationsPacket`: compressed payload ≤ 16 MB, entries ≤ 8192
  - `WorldDataPacket`: compressed payload ≤ 32 MB, chunks ≤ 16384
  - On overflow: log warning, clear lists, return — no huge allocations (invariant #4).

### Bandwidth impact

| Scenario | Before | After |
|---|---|---|
| 60-cell drag, 4 clients (host fan-out) | 60 × (3 clients) = **180 reliable sends**, ~7 KB | ~3 bulk messages × 3 clients = **9 sends**, ~2.5 KB |
| Existing bulk packets (anim / pickup) | Stuck until `MaxPackSize` reached | Flushed within 100–200 ms |
| `IntervalMs=100` bulk packet | Actual interval ~200 ms (monitor poll) | ~100 ms as declared |

Client → host upload is unchanged (each cell still produces one `HostBroadcastPacket` wrapper), but this leg has only one recipient so it doesn't scale with client count.

### Safety notes

- All packets extending `DragToolPacket` use `ProcessingIncoming` guard in their Harmony prefix → batching does not re-enter.
- `IClientRelayable` is opt-in. Existing `IBulkablePacket` users (`PlayAnimPacket`, `GroundItemPickedUpPacket`, etc.) don't implement it, so their direct-to-host path is unchanged.
- Re-enabling `BulkPacketMonitor` uses `Time.unscaledDeltaTime` → respects game-pause like existing mod timers.
- `_allowedClientRefreshDepth`-style scoping is main-thread only — all tool + sync code runs on Unity's main thread.

## Test plan

- [ ] Client drags sweep tool over 30+ cells → host dupes queue sweep chores, other clients see the cells marked
- [x] Host drags sweep → all clients see marked cells
- [x] Small drag (<10 cells) completes within 100–200 ms on remote clients (no stuck-in-queue)
- [x] Dig / Build / Deconstruct / Prioritize / Attack still work client → host → peers
- [ ] Existing anim sync + ground-item pickup still work (no regression from re-enabled flush)
- [ ] Verify packet count drop via `SyncStats` during a sustained drag
- [ ] Malformed build / utility / world / instantiation packet (oversize counts) is dropped with a warning, no OOM
- [ ] Tool throw during `OnDispatched` (force exception) → global `lastSelectedPriority` / `ProcessingIncoming` are restored
