### PR TITLE
Add unit tests for networking, sync and transport

### DIFF
--- a/ClassLibrary1/DebugTools/UnitTests/NetworkingTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/NetworkingTests.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using ONI_MP.Networking;
-using static UnityEngine.LowLevelPhysics2D.PhysicsQuery;
+using ONI_MP.Networking.Packets.Architecture;
+using ONI_MP.Networking.Packets.Core;
+using ONI_MP.Networking.Packets.World;
+using ONI_MP.Networking.Transport.Lan;
 
 namespace ONI_MP.DebugTools.UnitTests
 {
@@ -49,6 +53,156 @@ namespace ONI_MP.DebugTools.UnitTests
                     return UnitTestResult.Fail($"NetId {identity.NetId} has {matches.Count} identities");
             }
             return UnitTestResult.Pass("No duplicate network identities found");
+        }
+
+        [UnitTest(name: "TCP file transfer server ready (host, LAN)", category: "Networking")]
+        public static UnitTestResult TcpTransferServerReady()
+        {
+            if (!MultiplayerSession.IsHost)
+                return UnitTestResult.Fail("Not host, TCP transfer server only runs on the host");
+
+            if (!NetworkConfig.IsLanConfig())
+                return UnitTestResult.Fail("Not on Riptide/LAN transport");
+
+            if (NetworkConfig.TransportServer is not RiptideServer server)
+                return UnitTestResult.Fail("TransportServer is not a RiptideServer");
+
+            if (server.TcpTransfer == null)
+                return UnitTestResult.Fail("TcpFileTransfer is null (listener failed to start, UDP fallback in use)");
+
+            int riptidePort = Configuration.Instance.Host.LanSettings.Port;
+            return UnitTestResult.Pass($"TcpFileTransferServer running on port {riptidePort + 1}");
+        }
+
+        [UnitTest(name: "UDP save-transfer fallback pipeline registered", category: "Networking")]
+        public static UnitTestResult UdpFallbackAvailable()
+        {
+            if (!PacketRegistry.HasRegisteredPacket(typeof(SaveFileRequestPacket)))
+                return UnitTestResult.Fail("SaveFileRequestPacket not registered");
+
+            if (!PacketRegistry.HasRegisteredPacket(typeof(SaveFileChunkPacket)))
+                return UnitTestResult.Fail("SaveFileChunkPacket not registered");
+
+            return UnitTestResult.Pass("Save-transfer UDP fallback packets are registered");
+        }
+
+        [UnitTest(name: "Auto chunking: split and reassemble roundtrip", category: "Networking")]
+        public static UnitTestResult AutoChunkingWorks()
+        {
+            const int payloadSize = 2500;
+            const int chunkSize = 900;
+
+            byte[] payload = new byte[payloadSize];
+            var rnd = new Random(42);
+            rnd.NextBytes(payload);
+
+            int totalChunks = (payloadSize + chunkSize - 1) / chunkSize;
+            int sequence = ChunkedPacket.GetNextSequenceId();
+
+            var roundtripped = new List<byte[]>(totalChunks);
+            for (int i = 0; i < totalChunks; i++)
+            {
+                int offset = i * chunkSize;
+                int length = Math.Min(chunkSize, payloadSize - offset);
+                byte[] slice = new byte[length];
+                Array.Copy(payload, offset, slice, 0, length);
+
+                var chunk = new ChunkedPacket
+                {
+                    SequenceId = sequence,
+                    ChunkIndex = i,
+                    TotalChunks = totalChunks,
+                    ChunkData = slice
+                };
+
+                using var ms = new MemoryStream();
+                using (var w = new BinaryWriter(ms, Encoding.UTF8, true))
+                    chunk.Serialize(w);
+                ms.Position = 0;
+                var copy = new ChunkedPacket();
+                using (var r = new BinaryReader(ms, Encoding.UTF8, true))
+                    copy.Deserialize(r);
+
+                if (copy.SequenceId != sequence || copy.ChunkIndex != i || copy.TotalChunks != totalChunks)
+                    return UnitTestResult.Fail($"Chunk {i} header did not roundtrip");
+
+                if (copy.ChunkData.Length != length)
+                    return UnitTestResult.Fail($"Chunk {i} data length mismatch: got {copy.ChunkData.Length}, expected {length}");
+
+                roundtripped.Add(copy.ChunkData);
+            }
+
+            byte[] reassembled = new byte[payloadSize];
+            int writeOffset = 0;
+            foreach (var part in roundtripped)
+            {
+                Array.Copy(part, 0, reassembled, writeOffset, part.Length);
+                writeOffset += part.Length;
+            }
+
+            if (writeOffset != payloadSize)
+                return UnitTestResult.Fail($"Reassembled size {writeOffset} != original {payloadSize}");
+
+            for (int i = 0; i < payloadSize; i++)
+            {
+                if (reassembled[i] != payload[i])
+                    return UnitTestResult.Fail($"Reassembled byte {i} differs from original");
+            }
+
+            return UnitTestResult.Pass($"Chunked {payloadSize} bytes into {totalChunks} chunks and reassembled byte-identical");
+        }
+
+        [UnitTest(name: "All expected clients connected", category: "Networking")]
+        public static UnitTestResult AllClientsConnected()
+        {
+            if (!MultiplayerSession.InSession)
+                return UnitTestResult.Fail("Not in a multiplayer session");
+
+            var transportClients = NetworkConfig.GetConnectedClients();
+            if (transportClients.Count == 0)
+                return UnitTestResult.Fail("Transport reports zero connected clients");
+
+            int sessionCount = MultiplayerSession.ConnectedPlayers.Count;
+            if (sessionCount != transportClients.Count)
+                return UnitTestResult.Fail($"Session has {sessionCount} players but transport reports {transportClients.Count}");
+
+            foreach (var clientId in transportClients)
+            {
+                if (!MultiplayerSession.ConnectedPlayers.ContainsKey(clientId))
+                    return UnitTestResult.Fail($"Transport client {clientId} is missing from ConnectedPlayers");
+            }
+
+            return UnitTestResult.Pass($"{transportClients.Count} clients connected and tracked in session");
+        }
+
+        [UnitTest(name: "Packet routing: host never sends to itself", category: "Networking")]
+        public static UnitTestResult PacketRouting()
+        {
+            if (!MultiplayerSession.InSession)
+                return UnitTestResult.Fail("Not in a multiplayer session");
+
+            if (!MultiplayerSession.HostUserID.IsValid())
+                return UnitTestResult.Fail("HostUserID is not valid");
+
+            if (MultiplayerSession.IsHost && MultiplayerSession.LocalUserID != MultiplayerSession.HostUserID)
+                return UnitTestResult.Fail($"IsHost but LocalUserID {MultiplayerSession.LocalUserID} != HostUserID {MultiplayerSession.HostUserID}");
+
+            foreach (var kvp in MultiplayerSession.ConnectedPlayers)
+            {
+                var player = kvp.Value;
+                if (player == null)
+                    return UnitTestResult.Fail($"Player {kvp.Key} entry is null");
+                if (player.PlayerId != kvp.Key)
+                    return UnitTestResult.Fail($"ConnectedPlayers key {kvp.Key} != PlayerId {player.PlayerId}");
+            }
+
+            if (MultiplayerSession.IsClient)
+            {
+                if (MultiplayerSession.ConnectedPlayers.ContainsKey(MultiplayerSession.LocalUserID))
+                    return UnitTestResult.Fail("Client's own LocalUserID is listed in ConnectedPlayers (only host should be there)");
+            }
+
+            return UnitTestResult.Pass("Session routing state is consistent; host self-send guard can function");
         }
 
     }

--- a/ClassLibrary1/DebugTools/UnitTests/SyncTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/SyncTests.cs
@@ -1,0 +1,105 @@
+using System.IO;
+using System.Text;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Components;
+using ONI_MP.Networking.Packets.Architecture;
+using ONI_MP.Networking.Packets.Core;
+using ONI_MP.Networking.Packets.World;
+using UnityEngine;
+
+namespace ONI_MP.DebugTools.UnitTests
+{
+	public static class SyncTests
+	{
+		[UnitTest(name: "Duplicant positions in sync with host", category: "Sync")]
+		public static UnitTestResult DuplicantPositionsInSync()
+		{
+			if (!MultiplayerSession.InSession)
+				return UnitTestResult.Fail("Not in a multiplayer session");
+
+			const float MaxCellDelta = 2f;
+
+			int minionsChecked = 0;
+			foreach (var identity in NetworkIdentityRegistry.AllIdentities)
+			{
+				if (identity == null || identity.gameObject == null)
+					continue;
+
+				var prefabId = identity.gameObject.GetComponent<KPrefabID>();
+				if (prefabId == null || !prefabId.HasTag(GameTags.BaseMinion))
+					continue;
+
+				if (!identity.gameObject.TryGetComponent<EntityPositionHandler>(out var handler))
+					return UnitTestResult.Fail($"Minion '{identity.gameObject.name}' has no EntityPositionHandler");
+
+				minionsChecked++;
+
+				if (MultiplayerSession.IsHost)
+					continue;
+
+				if (handler.serverTimestamp == 0)
+					return UnitTestResult.Fail($"Minion '{identity.gameObject.name}' has not received a position packet yet");
+
+				float delta = Vector3.Distance(identity.gameObject.transform.position, handler.serverPosition);
+				if (delta > MaxCellDelta)
+					return UnitTestResult.Fail($"Minion '{identity.gameObject.name}' is {delta:F2} cells off server position");
+			}
+
+			if (minionsChecked == 0)
+				return UnitTestResult.Fail("No minions found in registry");
+
+			string mode = MultiplayerSession.IsHost ? "host" : "client";
+			return UnitTestResult.Pass($"Checked {minionsChecked} minions ({mode})");
+		}
+
+		[UnitTest(name: "Build progress bar pipeline intact", category: "Sync")]
+		public static UnitTestResult BuildProgressBarVisible()
+		{
+			var packet = new WorkableProgressPacket();
+
+			using var ms = new MemoryStream();
+			using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+				packet.Serialize(writer);
+			ms.Position = 0;
+
+			var copy = new WorkableProgressPacket();
+			using (var reader = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true))
+				copy.Deserialize(reader);
+
+			const int testNetId = -987654;
+			const float testPercent = 0.42f;
+			RemoteProgressRegistry.SetProgress(testNetId, RemoteProgressKind.WorkablePercent, testPercent, true, 2f, 5f);
+
+			if (!RemoteProgressRegistry.TryGetPercent(testNetId, RemoteProgressKind.WorkablePercent, out float percent))
+			{
+				RemoteProgressRegistry.Clear(testNetId, RemoteProgressKind.WorkablePercent, hideTarget: false);
+				return UnitTestResult.Fail("RemoteProgressRegistry did not return the stored entry");
+			}
+
+			RemoteProgressRegistry.Clear(testNetId, RemoteProgressKind.WorkablePercent, hideTarget: false);
+
+			if (Mathf.Abs(percent - testPercent) > 0.001f)
+				return UnitTestResult.Fail($"Stored percent {percent} differs from written {testPercent}");
+
+			return UnitTestResult.Pass("WorkableProgressPacket serialize/deserialize pipeline intact and RemoteProgressRegistry stores progress");
+		}
+
+		[UnitTest(name: "Hard sync not stuck in progress", category: "Sync")]
+		public static UnitTestResult HardSyncCompletes()
+		{
+			if (!PacketRegistry.HasRegisteredPacket(typeof(HardSyncPacket)))
+				return UnitTestResult.Fail("HardSyncPacket is not registered");
+			if (!PacketRegistry.HasRegisteredPacket(typeof(HardSyncCompletePacket)))
+				return UnitTestResult.Fail("HardSyncCompletePacket is not registered");
+
+			if (GameServerHardSync.IsHardSyncInProgress)
+				return UnitTestResult.Fail("Hard sync is currently in progress, rerun the test once it completes");
+
+			if (GameServerHardSync.hardSyncDoneThisCycle && !MultiplayerSession.InSession)
+				return UnitTestResult.Fail("hardSyncDoneThisCycle is set but session is not active");
+
+			string state = GameServerHardSync.hardSyncDoneThisCycle ? "completed this cycle" : "idle";
+			return UnitTestResult.Pass($"Hard sync machinery is {state}");
+		}
+	}
+}

--- a/ClassLibrary1/DebugTools/UnitTests/TransportTests.cs
+++ b/ClassLibrary1/DebugTools/UnitTests/TransportTests.cs
@@ -1,0 +1,121 @@
+using System.Linq;
+using ONI_MP.Networking;
+using ONI_MP.Networking.Transport.Lan;
+using ONI_MP.Networking.Transport.Steam;
+using Riptide;
+
+namespace ONI_MP.DebugTools.UnitTests
+{
+	public static class TransportTests
+	{
+		[UnitTest(name: "Transport server/client types match NetworkConfig", category: "Transport")]
+		public static UnitTestResult TransportMatchesConfig()
+		{
+			var transport = NetworkConfig.transport;
+			var server = NetworkConfig.TransportServer;
+			var client = NetworkConfig.TransportClient;
+
+			if (server == null)
+				return UnitTestResult.Fail("TransportServer is null");
+			if (client == null)
+				return UnitTestResult.Fail("TransportClient is null");
+
+			switch (transport)
+			{
+				case NetworkConfig.NetworkTransport.RIPTIDE:
+					if (server is not RiptideServer)
+						return UnitTestResult.Fail($"transport=RIPTIDE but server is {server.GetType().Name}");
+					if (client is not RiptideClient)
+						return UnitTestResult.Fail($"transport=RIPTIDE but client is {client.GetType().Name}");
+					return UnitTestResult.Pass("RIPTIDE config matches RiptideServer/RiptideClient");
+
+				case NetworkConfig.NetworkTransport.STEAMWORKS:
+					if (server is not SteamworksServer)
+						return UnitTestResult.Fail($"transport=STEAMWORKS but server is {server.GetType().Name}");
+					if (client is not SteamworksClient)
+						return UnitTestResult.Fail($"transport=STEAMWORKS but client is {client.GetType().Name}");
+					return UnitTestResult.Pass("STEAMWORKS config matches SteamworksServer/SteamworksClient");
+
+				default:
+					return UnitTestResult.Fail($"Unknown transport: {transport}");
+			}
+		}
+
+		[UnitTest(name: "Riptide timeout is 30000 ms", category: "Transport")]
+		public static UnitTestResult RiptideTimeoutCorrect()
+		{
+			if (!NetworkConfig.IsLanConfig())
+				return UnitTestResult.Fail("Not on Riptide/LAN transport");
+
+			const int ExpectedTimeoutMs = 30000;
+
+			Connection connection;
+			if (MultiplayerSession.IsHost)
+			{
+				var server = RiptideServer.ServerInstance;
+				if (server == null)
+					return UnitTestResult.Fail("Riptide Server instance is null");
+
+				connection = server.Clients.FirstOrDefault();
+				if (connection == null)
+					return UnitTestResult.Fail("Server has no client connections to read timeout from");
+			}
+			else if (MultiplayerSession.IsClient)
+			{
+				var client = RiptideClient.Client;
+				if (client?.Connection == null)
+					return UnitTestResult.Fail("Riptide Client connection is null");
+
+				connection = client.Connection;
+			}
+			else
+			{
+				return UnitTestResult.Fail("Neither host nor client");
+			}
+
+			if (connection.TimeoutTime != ExpectedTimeoutMs)
+				return UnitTestResult.Fail($"Connection.TimeoutTime is {connection.TimeoutTime} ms, expected {ExpectedTimeoutMs} ms (might be set in seconds instead of ms)");
+
+			string role = MultiplayerSession.IsHost ? "Server" : "Client";
+			return UnitTestResult.Pass($"Riptide {role} timeout = {connection.TimeoutTime} ms");
+		}
+
+		[UnitTest(name: "Connection stable", category: "Transport")]
+		public static UnitTestResult ConnectionStable()
+		{
+			if (!MultiplayerSession.InSession)
+				return UnitTestResult.Fail("Not in a multiplayer session");
+
+			if (!NetworkConfig.IsLanConfig())
+				return UnitTestResult.Fail("Stability check only implemented for Riptide transport");
+
+			if (MultiplayerSession.IsHost)
+			{
+				var server = RiptideServer.ServerInstance;
+				if (server == null || !server.IsRunning)
+					return UnitTestResult.Fail("Riptide Server is not running");
+
+				int connected = 0;
+				foreach (var connection in server.Clients)
+				{
+					if (!connection.IsNotConnected)
+						connected++;
+				}
+
+				if (connected == 0)
+					return UnitTestResult.Fail("No active connections on server");
+
+				return UnitTestResult.Pass($"Server running with {connected} active connection(s)");
+			}
+
+			var client = RiptideClient.Client;
+			if (client == null)
+				return UnitTestResult.Fail("Riptide Client instance is null");
+			if (!client.IsConnected)
+				return UnitTestResult.Fail("Riptide Client is not connected");
+
+			int rtt = client.SmoothRTT;
+			return UnitTestResult.Pass($"Client connected, smoothed RTT = {rtt} ms");
+		}
+	}
+}


### PR DESCRIPTION
- 11 new tests 
- Networking (5): TCP file transfer server, UDP save-transfer fallback, auto chunking roundtrip, all clients connected, packet routing guard
- Sync (3): duplicant position drift vs host, build progress bar pipeline, hard sync state
- Transport (3): transport type matches NetworkConfig, Riptide timeout 30000 ms via Connection.TimeoutTime, connection stability
- Verified green in a LAN host session with 1 client

- Found bug while testing: NetworkIdentityRegistry ends up empty after session stop + restart without world reload, minion/anim tests fail in that state (separate fix)

# In short, many new tests :)