### PR TITLE
fix(battery): sync joules and meter to clients

### DIFF
--- a/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
+++ b/ClassLibrary1/Networking/Components/StructureStateSyncer.cs
@@ -120,6 +120,8 @@ namespace ONI_MP.Networking.Components
 		// Cached reflection field
 		private static System.Reflection.FieldInfo _batteryJoulesField;
 		private static bool _batteryFieldLookupAttempted = false;
+		private static System.Reflection.FieldInfo _batteryMeterField;
+		private static bool _batteryMeterFieldLookupAttempted = false;
 
 		// Static handler for client-side reception
 		public static void HandlePacket(StructureStatePacket packet)
@@ -128,7 +130,7 @@ namespace ONI_MP.Networking.Components
 
 			if (!Grid.IsValidCell(packet.Cell)) return;
 
-			GameObject go = Grid.Objects[packet.Cell, (int)Grid.SceneLayer.Building];
+			GameObject go = Grid.Objects[packet.Cell, (int)ObjectLayer.Building];
 			if (go == null) return;
 
 			// Apply state
@@ -141,7 +143,7 @@ namespace ONI_MP.Networking.Components
 					if (_batteryJoulesField == null && !_batteryFieldLookupAttempted)
 					{
 						_batteryFieldLookupAttempted = true;
-						_batteryJoulesField = typeof(Battery).GetField("joulesAvailable", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+						_batteryJoulesField = typeof(Battery).GetField("joulesAvailable", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
 					}
 					if (_batteryJoulesField != null)
 					{
@@ -160,6 +162,29 @@ namespace ONI_MP.Networking.Components
 				{
 					using var allowClientRefresh = BatteryTrackerPatch.AllowClientRefresh();
 					tracker.UpdateData();
+				}
+
+				// Drive the visual fill meter: normally updated inside Battery.EnergySim200ms,
+				// which is skipped on clients by BatteryClientSimSkipPatch.
+				try
+				{
+					if (_batteryMeterField == null && !_batteryMeterFieldLookupAttempted)
+					{
+						_batteryMeterFieldLookupAttempted = true;
+						_batteryMeterField = typeof(Battery).GetField("meter", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+					}
+					if (_batteryMeterField != null)
+					{
+						var meter = _batteryMeterField.GetValue(battery) as MeterController;
+						if (meter != null && battery.capacity > 0f)
+						{
+							meter.SetPositionPercent(Mathf.Clamp01(packet.Value / battery.capacity));
+						}
+					}
+				}
+				catch (System.Exception ex)
+				{
+					DebugConsole.LogError($"[StructureStateSyncer] Failed to update meter: {ex}");
 				}
 			}
 

--- a/ClassLibrary1/Patches/World/BatteryClientSimSkipPatch.cs
+++ b/ClassLibrary1/Patches/World/BatteryClientSimSkipPatch.cs
@@ -1,0 +1,36 @@
+using HarmonyLib;
+using ONI_MP.Networking;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.World
+{
+	// Clients receive joules snapshots from the host via StructureStateSyncer.
+	// If the local power sim also runs, it overwrites those snapshots every 200ms,
+	// so batteries drift and never appear to charge/discharge correctly.
+	internal static class BatteryClientSimSkipPatch
+	{
+		private static bool SkipOnClient()
+		{
+			using var _ = Profiler.Scope();
+			return MultiplayerSession.IsClient;
+		}
+
+		[HarmonyPatch(typeof(Battery), nameof(Battery.EnergySim200ms))]
+		public static class Battery_EnergySim200ms_Patch
+		{
+			public static bool Prefix() => !SkipOnClient();
+		}
+
+		[HarmonyPatch(typeof(Battery), nameof(Battery.AddEnergy))]
+		public static class Battery_AddEnergy_Patch
+		{
+			public static bool Prefix() => !SkipOnClient();
+		}
+
+		[HarmonyPatch(typeof(Battery), nameof(Battery.ConsumeEnergy), new[] { typeof(float) })]
+		public static class Battery_ConsumeEnergy_Patch
+		{
+			public static bool Prefix() => !SkipOnClient();
+		}
+	}
+}


### PR DESCRIPTION
Fix battery sync on clients
                                                                          
  Batteries never visibly charged/discharged on client. They displayed
  stale values and the fill meter was permanently empty even though the   
  host's grid was running normally.
                                                                          
  Root cause                                                

  In StructureStateSyncer.HandlePacket, the client looked up the target   
  building with:
                                                                          
  Grid.Objects[packet.Cell, (int)Grid.SceneLayer.Building]  

  Grid.SceneLayer.Building is the render-order layer (value 19). The      
  Grid.Objects[,] array is indexed by ObjectLayer, where
  ObjectLayer.Building = 1. The client was reading from the wrong slot on 
  every packet, always got null, and silently bailed out — packets arrived
   every 500ms with correct joules, but nothing was ever written to any
  Battery. Every other site in the codebase (ChoreFactory,
  BuildingConfigPacket, BuildToolPatch, etc.) correctly uses
  ObjectLayer.Building; this one path was wrong.

  Changes

  StructureStateSyncer.cs                                                 
   
  - Fix the layer lookup: Grid.SceneLayer.Building - ObjectLayer.Building.
   This alone restores numeric sync of JoulesAvailable on the client.
  - Drive the visual meter from the packet handler: Battery.EnergySim200ms
   is what normally calls meter.SetPositionPercent(...) to animate the    
  fill bar. Since we skip that method on the client (see below), the meter
   would stay empty. HandlePacket now looks up the private meter field via
   reflection and calls SetPositionPercent(clamp01(value / capacity))
  after writing joules.
  - Broaden reflection binding to Public | NonPublic | Instance so
  publicized-vs-stock assemblies both resolve the field.                  
   
  BatteryClientSimSkipPatch.cs (new)                                      
                                                            
  Harmony Prefix patches that return false on the client for:             
  - Battery.EnergySim200ms
  - Battery.AddEnergy                                                     
  - Battery.ConsumeEnergy(float)                            
                                
  Why: the host snapshots every 500ms. In between snapshots, the client's 
  own CircuitManager would still tick EnergySim200ms / AddEnergy /        
  ConsumeEnergy every 200ms based on its local view of the circuit,       
  modifying joulesAvailable and letting it drift from the host's value.   
  With the sim paths stubbed on the client, joulesAvailable is only ever
  written by the packet handler — the client becomes a pure mirror of host
   state and no drift is possible between snapshots.

  The host runs these methods normally, so simulation is unchanged there. 
   
  BatteryTrackerPatch.cs (unchanged)                                      
                                                            
  Kept 0.5.2 AllowClientRefresh disposable and the hard-sync guard.     
  HandlePacket still opens the scope and calls tracker.UpdateData() to
  register the battery with the client's CircuitManager so consumers      
  render as powered.                                        
                                     

  Verification

  - [ ] Host save with a working power grid (generator - wire - battery -    
  consumer), client joins.
  - [ ] Battery readout, sidescreen joules, power-overlay percent, and       
  fill-bar animation all move in sync with host through both charging     
  (surplus) and discharging (deficit) states.
  - [ ] Toggling generators on/off propagates to Operational.IsActive on     
  client without UI lag.                                                  
  - [ ] Grid with ~20 batteries: no packet-storm symptoms (500ms interval +
  epsilon gate keeps rate bounded).                                       
                                                            
  Note on approach                                                        
                                                            
  The layer-index fix is the actual bug. The sim-skip patch is            
  defense-in-depth: without the layer fix, sim-skip alone fixes nothing
  (packets never land); with the layer fix alone, values sync but can     
  visibly jitter between snapshots if the client's circuit math diverges
  from host. Shipping both gives a fully stable mirror.
