### PR TITLE
Fix client crash when placing jukebox

### DIFF
--- a/ClassLibrary1/Patches/World/Buildings/PhonoboxPatch.cs
+++ b/ClassLibrary1/Patches/World/Buildings/PhonoboxPatch.cs
@@ -1,0 +1,19 @@
+using HarmonyLib;
+using ONI_MP.Networking;
+using Shared.Profiling;
+
+namespace ONI_MP.Patches.World.Buildings
+{
+	internal class PhonoboxPatch
+	{
+		[HarmonyPatch(typeof(Phonobox), nameof(Phonobox.UpdateChores))]
+		public class Phonobox_UpdateChores_Patch
+		{
+			public static bool Prefix()
+			{
+				using var _ = Profiler.Scope();
+				return !MultiplayerSession.IsClient;
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Jukebox placement crashed all clients with a NullReferenceException in Phonobox.UpdateChores
- Phonobox.OnSpawn calls StartSM() before initializing its chores/workables arrays. On clients the state machine transitions straight to operational and calls UpdateChores before the arrays exist
- Harmony prefix skips UpdateChores on clients. Chores are host-authoritative in this mod, clients only receive synced duplicant movement