### PR TITLE
pickup_item: fix source stack getting destroyed when it still exists

### DIFF
--- a/ONI_Together/Networking/Packets/DuplicantActions/DuplicantCarryItemPacket.cs
+++ b/ONI_Together/Networking/Packets/DuplicantActions/DuplicantCarryItemPacket.cs
@@ -116,9 +116,6 @@ namespace ONI_Together.Networking.Packets.DuplicantActions
 				var firstAnim = animData.GetAnim(0);
 				animCtrl.Play(firstAnim.hash, KAnim.PlayMode.Loop);
 			}
-
-			//DebugConsole.Log($"[DuplicantCarryItemPacket] Carry proxy created: {proxyName}");
-			ShowPopFX(dupeAnim.transform);
 		}
 
 		private static KAnimFile ResolveAnim(string name)
@@ -168,26 +165,5 @@ namespace ONI_Together.Networking.Packets.DuplicantActions
 			}
 		}
 
-		private void ShowPopFX(Transform target)
-		{
-			if (PopFXManager.Instance == null || ItemPrefabHash == 0)
-				return;
-
-			var prefab = Assets.GetPrefab(new Tag(ItemPrefabHash));
-			if (prefab == null)
-				return;
-
-			string text = string.Format(
-				global::STRINGS.UI.PICKEDUP,
-				GameUtil.GetFormattedMass(1),
-				prefab.GetProperName());
-
-			PopFXManager.Instance.SpawnFX(
-				Def.GetUISprite(prefab).first,
-				PopFXManager.Instance.sprite_Negative,
-				text,
-				target,
-				Vector3.zero);
-		}
 	}
 }

--- a/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
+++ b/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
@@ -54,7 +54,8 @@ namespace ONI_Together.Networking.Packets.World
             if (SourceRemains)
             {
                 var primaryElement = pickupable.GetComponent<PrimaryElement>();
-                primaryElement?.Units = RemainingUnits;
+                if (primaryElement != null)
+                    primaryElement.Units = RemainingUnits;
             }
             else
             {

--- a/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
+++ b/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
@@ -41,7 +41,9 @@ namespace ONI_Together.Networking.Packets.World
                 return; // skip
 
             DisplayFX(pickupable.gameObject);
-            Util.KDestroyGameObject(pickupable.gameObject);
+
+            if (!pickupable.storage.items.Contains(pickupable.gameObject))
+                Util.KDestroyGameObject(pickupable.gameObject);
         }
 
         public void DisplayFX(GameObject go)

--- a/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
+++ b/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
@@ -16,6 +16,9 @@ namespace ONI_Together.Networking.Packets.World
     public class PickupItemPacket : IPacket, IBulkablePacket
     {
         public int NetId;
+        public float UnitsTaken;
+        public bool SourceRemains;
+        public float RemainingUnits;
 
         public int MaxPackSize => 500;
 
@@ -25,12 +28,18 @@ namespace ONI_Together.Networking.Packets.World
         {
             using var _ = Profiler.Scope();
             writer.Write(NetId);
+            writer.Write(UnitsTaken);
+            writer.Write(SourceRemains);
+            writer.Write(RemainingUnits);
         }
 
         public void Deserialize(BinaryReader reader)
         {
             using var _ = Profiler.Scope();
             NetId = reader.ReadInt32();
+            UnitsTaken = reader.ReadSingle();
+            SourceRemains = reader.ReadBoolean();
+            RemainingUnits = reader.ReadSingle();
         }
 
         public void OnDispatched()
@@ -42,8 +51,15 @@ namespace ONI_Together.Networking.Packets.World
 
             DisplayFX(pickupable.gameObject);
 
-            if (!pickupable.storage.items.Contains(pickupable.gameObject))
+            if (SourceRemains)
+            {
+                var primaryElement = pickupable.GetComponent<PrimaryElement>();
+                primaryElement?.Units = RemainingUnits;
+            }
+            else
+            {
                 Util.KDestroyGameObject(pickupable.gameObject);
+            }
         }
 
         public void DisplayFX(GameObject go)
@@ -59,7 +75,7 @@ namespace ONI_Together.Networking.Packets.World
             Transform target_transform = go.transform;
             Vector3 offset = Vector3.zero;
 
-            string text = (Assets.IsTagCountable(go.PrefabID()) ? string.Format(locString, (int)component.Units, go.GetProperName()) : string.Format(locString, GameUtil.GetFormattedMass(component.Units), go.GetProperName()));
+            string text = (Assets.IsTagCountable(go.PrefabID()) ? string.Format(locString, (int)UnitsTaken, go.GetProperName()) : string.Format(locString, GameUtil.GetFormattedMass(UnitsTaken * component.MassPerUnit), go.GetProperName()));
             PopFXManager.Instance.SpawnFX(Def.GetUISprite(go).first, PopFXManager.Instance.sprite_Plus, text, target_transform, offset);
         }
     }

--- a/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
+++ b/ONI_Together/Networking/Packets/World/PickupItemPacket.cs
@@ -17,8 +17,8 @@ namespace ONI_Together.Networking.Packets.World
     {
         public int NetId;
         public float UnitsTaken;
+        public float UnitsRemaining;
         public bool SourceRemains;
-        public float RemainingUnits;
 
         public int MaxPackSize => 500;
 
@@ -29,8 +29,8 @@ namespace ONI_Together.Networking.Packets.World
             using var _ = Profiler.Scope();
             writer.Write(NetId);
             writer.Write(UnitsTaken);
+            writer.Write(UnitsRemaining);
             writer.Write(SourceRemains);
-            writer.Write(RemainingUnits);
         }
 
         public void Deserialize(BinaryReader reader)
@@ -38,8 +38,8 @@ namespace ONI_Together.Networking.Packets.World
             using var _ = Profiler.Scope();
             NetId = reader.ReadInt32();
             UnitsTaken = reader.ReadSingle();
+            UnitsRemaining = reader.ReadSingle();
             SourceRemains = reader.ReadBoolean();
-            RemainingUnits = reader.ReadSingle();
         }
 
         public void OnDispatched()
@@ -55,7 +55,7 @@ namespace ONI_Together.Networking.Packets.World
             {
                 var primaryElement = pickupable.GetComponent<PrimaryElement>();
                 if (primaryElement != null)
-                    primaryElement.Units = RemainingUnits;
+                    primaryElement.Units = UnitsRemaining;
             }
             else
             {

--- a/ONI_Together/Patches/World/PickupablePatches.cs
+++ b/ONI_Together/Patches/World/PickupablePatches.cs
@@ -7,12 +7,14 @@ using Shared.Profiling;
 
 namespace ONI_Together.Patches.World
 {
-	public static class PickupablePatches
-	{
+    public static class PickupablePatches
+    {
+        // `TakeUnit` is not patched separately: it delegates to `Take`, so a patch on it
+        // would send a second packet for the same pickup.
         [HarmonyPatch(typeof(Pickupable), nameof(Pickupable.Take))]
         public static class PickupableTakePatch
         {
-            public static void Postfix(Pickupable __instance)
+            public static void Postfix(Pickupable __instance, Pickupable __result)
             {
                 using var _ = Profiler.Scope();
                 try
@@ -20,33 +22,24 @@ namespace ONI_Together.Patches.World
                     if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession)
                         return;
 
-                    var identity = __instance.GetNetIdentity();
-                    if (identity == null || identity.NetId == 0)
-                        return;
-                    PacketSender.SendToAllClients(new PickupItemPacket { NetId = identity.NetId });
-                }
-                catch (System.Exception ex)
-                {
-                    DebugConsole.LogError($"[PickupableTakePatch] Exception: {ex}");
-                }
-            }
-        }
-
-        [HarmonyPatch(typeof(Pickupable), nameof(Pickupable.TakeUnit))]
-        public static class PickupableTakeUnitPatch
-        {
-            public static void Postfix(Pickupable __instance)
-            {
-                using var _ = Profiler.Scope();
-                try
-                {
-                    if (!MultiplayerSession.IsHost || !MultiplayerSession.InSession)
+                    // nothing was taken
+                    if (__result == null)
                         return;
 
                     var identity = __instance.GetNetIdentity();
                     if (identity == null || identity.NetId == 0)
                         return;
-                    PacketSender.SendToAllClients(new PickupItemPacket { NetId = identity.NetId });
+
+                    // A partial take splits off a new pickupable and leaves the source stack alive.
+                    // A full take returns the source itself.
+                    bool sourceRemains = __result != __instance;
+                    PacketSender.SendToAllClients(new PickupItemPacket
+                    {
+                        NetId = identity.NetId,
+                        UnitsTaken = __result.TotalAmount,
+                        SourceRemains = sourceRemains,
+                        RemainingUnits = sourceRemains ? __instance.TotalAmount : 0f
+                    });
                 }
                 catch (System.Exception ex)
                 {

--- a/ONI_Together/Patches/World/PickupablePatches.cs
+++ b/ONI_Together/Patches/World/PickupablePatches.cs
@@ -37,8 +37,8 @@ namespace ONI_Together.Patches.World
                     {
                         NetId = identity.NetId,
                         UnitsTaken = __result.TotalAmount,
+                        UnitsRemaining = sourceRemains ? __instance.TotalAmount : 0f,
                         SourceRemains = sourceRemains,
-                        RemainingUnits = sourceRemains ? __instance.TotalAmount : 0f
                     });
                 }
                 catch (System.Exception ex)


### PR DESCRIPTION
This PR fixes four issues with pickups:
- If the amount in a stack was large enough, if a dupe took a piece of it, the original stack would disappear.
- When a dupe picked a piece of stack up, the game would say they picked up the full amount in the stack. (e.g. 17 tons in stack, takes 200 kg, game says they took 17 tons)
- `Pickupable.TakeUnit` just calls `Pickupable.Take`, so patching both methods sent two packets per unit-based pickup. No need for both patches.
- `DisplayFX` didn't take the `MassPerUnit` into account.

# Before being picked up

## Host

<img width="999" height="742" alt="image" src="https://github.com/user-attachments/assets/706f7256-f67e-46f6-8136-bc0fb142b854" />

## Client

<img width="942" height="744" alt="image" src="https://github.com/user-attachments/assets/cf54d1ad-edc6-448c-a9f2-c3612e871e0d" />

# After being picked up

## Host

<img width="1195" height="758" alt="image" src="https://github.com/user-attachments/assets/bf0a8496-4967-4fc7-9fa4-3f366420d335" />

## Client

<img width="1153" height="563" alt="image" src="https://github.com/user-attachments/assets/046c6746-70ef-4052-881e-779c25c2e5e5" />
