### PR TITLE
spawn_prefab: fix missing constructor

### DIFF
--- a/ONI_Together/Networking/Packets/World/SpawnPrefabPacket.cs
+++ b/ONI_Together/Networking/Packets/World/SpawnPrefabPacket.cs
@@ -18,6 +18,8 @@ public class SpawnPrefabPacket : IPacket
     public byte DiseaseIndex;
     public int DiseaseCount;
 
+    public SpawnPrefabPacket() { }
+
     public SpawnPrefabPacket(int netId, int hash, Vector3 position)
     {
         NetId = netId;


### PR DESCRIPTION
This fixes `PacketRegistry.Create` blowing up when instantiating `SpawnPrefabPacket`.

AFAIK `SpawnPrefabPacket` isn't even used, I'm not sure if it's a planned feature or what, feel free to close if not necessary.