### PR TITLE
flatulence: fix dupes farting in the minion select screen

### DIFF
--- a/ONI_Together/Patches/Duplicant/Flatulence_Patch.cs
+++ b/ONI_Together/Patches/Duplicant/Flatulence_Patch.cs
@@ -31,7 +31,7 @@ namespace ONI_Together.Patches.Duplicant
 				if (__instance.smi.IsNullOrDestroyed() || __instance.smi.IsNullOrStopped())
 					return false;
 
-				bool preview = (__instance.PrefabID() != GameTags.MinionSelectPreview);
+				bool preview = (__instance.PrefabID() == GameTags.MinionSelectPreview);
 				bool client = MultiplayerSession.IsClient;
 
 				if (client || preview)

--- a/ONI_Together/Patches/Duplicant/Flatulence_Patch.cs
+++ b/ONI_Together/Patches/Duplicant/Flatulence_Patch.cs
@@ -25,7 +25,7 @@ namespace ONI_Together.Patches.Duplicant
 			{
 				using var _ = Profiler.Scope();
 
-				if(__instance.IsNullOrDestroyed() || __instance.gameObject.IsNullOrDestroyed())
+				if (__instance.IsNullOrDestroyed() || __instance.gameObject.IsNullOrDestroyed())
 					return false;
 
 				if (__instance.smi.IsNullOrDestroyed() || __instance.smi.IsNullOrStopped())


### PR DESCRIPTION
Speaks for itself; the check was inverted and dupes were farting in the minion select screen.

@Lyraedan This might not be required anymore?
<img width="1242" height="136" alt="image" src="https://github.com/user-attachments/assets/9b0d97ae-752d-481d-a380-bc1ca068eef0" />
 